### PR TITLE
[FEAT] robots.txt 및 메타태그 정보 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
     <meta
       name="keywords"
       content="템플스테이, 절로가, 여행, 사찰, 명상, 힐링, 템플스테이 추천, 휴식형 템플스테이, 체험형 템플스테이" />
+    <link rel="canonical" href="https://www.gototemplestay.com/" />
   </head>
   <body>
     <!-- Google Tag Manager (noscript) -->

--- a/index.html
+++ b/index.html
@@ -4,7 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="public/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>절로가</title>
+    <title>절로가 | 템플스테이 간편 탐색 서비스</title>
+    <meta
+      name="description"
+      content="템플스테이를 만나는 가장 쉬운 방법, 전국 사찰의 템플스테이 프로그램을 한눈에 비교해요. 평범한 하루에 특별한 힐링을 더하고, 자연 속에서 명상과 쉼을 경험해 보세요." />
 
     <!-- Google Tag Manager -->
     <script>
@@ -21,14 +24,16 @@
     </script>
     <!-- End Google Tag Manager -->
 
-    <meta property="og:title" content="절로가" />
+    <meta property="og:title" content="절로가 | 템플스테이 간편 탐색 서비스," />
     <meta property="og:image" content="public/img_og.png" />
     <meta property="og:description" content="템플스테이를 만나는 가장 쉬운 방법," />
     <meta property="og:url" content="https://www.gototemplestay.com/" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="절로가" />
     <meta property="og:locale" content="ko_KR" />
-    <meta name="keywords" content="템플스테이, 절로가, 여행, 사찰, 명상, 힐링" />
+    <meta
+      name="keywords"
+      content="템플스테이, 절로가, 여행, 사찰, 명상, 힐링, 템플스테이 추천, 휴식형 템플스테이, 체험형 템플스테이" />
   </head>
   <body>
     <!-- Google Tag Manager (noscript) -->

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>절로가 | 템플스테이 간편 탐색 서비스</title>
     <meta
       name="description"
-      content="템플스테이를 만나는 가장 쉬운 방법, 전국 사찰의 템플스테이 프로그램을 한눈에 비교해요. 평범한 하루에 특별한 힐링을 더하고, 자연 속에서 명상과 쉼을 경험해 보세요." />
+      content="템플스테이를 만나는 가장 쉬운 방법, 전국 사찰의 템플스테이 프로그램을 한눈에 비교하고, 나에게 맞는 힐링을 찾아보세요. 자연 속에서 명상과 쉼을 경험하며, 평범한 하루에 특별한 휴식을 더해 보세요." />
 
     <!-- Google Tag Manager -->
     <script>
@@ -24,9 +24,11 @@
     </script>
     <!-- End Google Tag Manager -->
 
-    <meta property="og:title" content="절로가 | 템플스테이 간편 탐색 서비스," />
+    <meta property="og:title" content="절로가 | 템플스테이 간편 탐색 서비스" />
     <meta property="og:image" content="public/img_og.png" />
-    <meta property="og:description" content="템플스테이를 만나는 가장 쉬운 방법," />
+    <meta
+      property="og:description"
+      content="템플스테이를 만나는 가장 쉬운 방법, 전국 사찰의 템플스테이 프로그램을 한눈에 비교하고, 나에게 맞는 힐링을 찾아보세요. 자연 속에서 명상과 쉼을 경험하며, 평범한 하루에 특별한 휴식을 더해 보세요." />
     <meta property="og:url" content="https://www.gototemplestay.com/" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="절로가" />

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow:
+Sitemap: https://www.gototemplestay.com/sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,9 @@
 User-agent: *
-Disallow:
+
+Disallow: /login/
+Disallow: /loginStart/
+Disallow: /auth/
+Disallow: /onboarding/
+Disallow: /onboarding?
+
 Sitemap: https://www.gototemplestay.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset
+      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+
+
+<url>
+  <loc>https://www.gototemplestay.com/</loc>
+  <lastmod>2025-01-26T17:24:56+00:00</lastmod>
+</url>
+
+
+</urlset>

--- a/src/components/card/lookCard/LookCard.tsx
+++ b/src/components/card/lookCard/LookCard.tsx
@@ -21,13 +21,10 @@ const LookCard = ({ name = '일로와' }: LookCardProps) => {
       />
       <div className={styles.textWrapper}>
         <div className={styles.textBox}>
-          <span>
-            <span className={styles.name}>{name}</span> 님을 위한
-            <br />
-            템플스테이,
-            <br />
-            찾으러 가볼까요?
-          </span>
+          <h1 className={styles.titleStyle}>
+            <span className={styles.name}>{name}</span>
+            {`님을 위한\n템플스테이,\n찾으러 가볼까요?`}
+          </h1>
           <div>
             <BasicBtn
               onClick={() => handleSearch()}

--- a/src/components/card/lookCard/lookCard.css.ts
+++ b/src/components/card/lookCard/lookCard.css.ts
@@ -37,3 +37,7 @@ export const textBox = style({
 export const name = style({
   ...theme.FONTS.h0Sb22,
 });
+
+export const titleStyle = style({
+  whiteSpace: 'pre-line',
+});

--- a/src/components/card/mapCard/MapCard.tsx
+++ b/src/components/card/mapCard/MapCard.tsx
@@ -8,7 +8,7 @@ const MapCard = () => {
   return (
     <section className={styles.mapWrapper}>
       <div className={styles.titleBox}>
-        <h2 className={styles.title}>원하는 지역을 골라보세요!</h2>
+        <p className={styles.title}>원하는 지역을 골라보세요!</p>
         <Icon.IcnDoubleArrowDown />
       </div>
       <Map />

--- a/src/components/card/popularCard/PopularCard.tsx
+++ b/src/components/card/popularCard/PopularCard.tsx
@@ -57,7 +57,7 @@ const PopularCard = ({
         </div>
         <div className={styles.bottomWrapper}>
           <div className={styles.bottomContainer}>
-            <span className={styles.templeName}>{templeName}</span>
+            <h3 className={styles.templeName}>{templeName}</h3>
             <div className={styles.bottomBox}>
               <span>{templeLoc}</span>
               <Icon.IcnDivider />

--- a/src/components/card/popularCard/PopularCard.tsx
+++ b/src/components/card/popularCard/PopularCard.tsx
@@ -10,9 +10,9 @@ interface PopularCardProps {
   templeLoc: string;
   templeImg: string;
   tag: string;
-  onClick: () => void;
   isLiked?: boolean;
   onLikeToggle: (liked: boolean) => void;
+  link: string;
 }
 
 const PopularCard = ({
@@ -21,9 +21,9 @@ const PopularCard = ({
   templeLoc,
   templeImg,
   tag,
-  onClick,
   isLiked = false,
   onLikeToggle,
+  link,
 }: PopularCardProps) => {
   const [liked, setLiked] = useState(isLiked);
 
@@ -41,16 +41,7 @@ const PopularCard = ({
   };
 
   return (
-    <div
-      className={styles.cardWrapper}
-      onClick={onClick}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          onClick();
-        }
-      }}>
+    <a href={link} className={styles.cardWrapper}>
       <div>
         <div className={styles.imgBox} style={{ backgroundImage: `url(${templeImg})` }}>
           <RankBtn ranking={ranking} />
@@ -69,7 +60,7 @@ const PopularCard = ({
           </button>
         </div>
       </div>
-    </div>
+    </a>
   );
 };
 

--- a/src/components/card/templeStayCard/TempleStayCard.tsx
+++ b/src/components/card/templeStayCard/TempleStayCard.tsx
@@ -16,8 +16,8 @@ interface TempleStayCardProps {
   liked: boolean;
   layout: 'vertical' | 'horizontal';
   onToggleWishlist: (templestayId: number, liked: boolean) => void;
-  onClick?: (templestayId: number) => void;
   onRequireLogin?: () => void;
+  link: string;
 }
 
 const TempleStayCard = ({
@@ -31,7 +31,7 @@ const TempleStayCard = ({
   liked,
   layout,
   onToggleWishlist,
-  onClick,
+  link,
   onRequireLogin,
 }: TempleStayCardProps) => {
   const [isWished, setIsWished] = useState(liked);
@@ -51,10 +51,7 @@ const TempleStayCard = ({
   };
 
   return (
-    <article
-      className={isHorizontal ? styles.horizontalContainer : styles.verticalContainer}
-      onClick={() => onClick?.(templestayId)}
-      role="presentation">
+    <a href={link} className={isHorizontal ? styles.horizontalContainer : styles.verticalContainer}>
       {imgUrl ? (
         <section className={isHorizontal ? styles.horizontalImgSection : styles.verticalImgSection}>
           <img
@@ -82,7 +79,7 @@ const TempleStayCard = ({
         region={region}
         type={type}
       />
-    </article>
+    </a>
   );
 };
 

--- a/src/components/card/templeStayCard/searchCardList/SearchCardList.tsx
+++ b/src/components/card/templeStayCard/searchCardList/SearchCardList.tsx
@@ -1,6 +1,3 @@
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
-
 import TempleStayCard from '../TempleStayCard';
 import container from './searchCardList.css';
 
@@ -26,12 +23,6 @@ const SearchCardList = ({
   onToggleWishlist,
   onRequireLogin,
 }: SearchCardListProps) => {
-  const navigate = useNavigate();
-
-  const handleCardClick = (templestayId: number) => {
-    navigate(`/detail/${templestayId}`);
-  };
-
   return (
     <section className={container}>
       {data.map((temple) => (
@@ -47,8 +38,8 @@ const SearchCardList = ({
           liked={temple.liked}
           layout={layout}
           onToggleWishlist={onToggleWishlist}
-          onClick={() => handleCardClick(temple.templestayId)}
           onRequireLogin={onRequireLogin}
+          link={`/detail/${temple.templestayId}`}
         />
       ))}
     </section>

--- a/src/components/card/templeStayCard/wishCardList/WishCardList.tsx
+++ b/src/components/card/templeStayCard/wishCardList/WishCardList.tsx
@@ -1,5 +1,4 @@
 import TempleStayCard from '@components/card/templeStayCard/TempleStayCard';
-import React from 'react';
 
 import container from './wishCardList.css';
 
@@ -16,14 +15,8 @@ interface WishCardListProps {
   }[];
   layout: 'vertical' | 'horizontal';
   onToggleWishlist: (templestayId: number, liked: boolean) => void;
-  onClick?: (templestayId: number) => void;
 }
-const WishCardList = ({
-  data,
-  layout = 'vertical',
-  onToggleWishlist,
-  onClick,
-}: WishCardListProps) => {
+const WishCardList = ({ data, layout = 'vertical', onToggleWishlist }: WishCardListProps) => {
   return (
     <section className={container}>
       {data.map((temple) => (
@@ -39,7 +32,7 @@ const WishCardList = ({
           liked={temple.liked}
           layout={layout}
           onToggleWishlist={onToggleWishlist}
-          onClick={onClick}
+          link={`/detail/${temple.templestayId}`}
         />
       ))}
     </section>

--- a/src/components/carousel/curationCarousel/CurationCarousel.tsx
+++ b/src/components/carousel/curationCarousel/CurationCarousel.tsx
@@ -2,8 +2,6 @@ import CurationCard from '@components/curation/curationCard/CurationCard';
 import { CURATION_INFO } from '@constants/curationInfo';
 import useCarousel from '@hooks/useCarousel';
 import registDragEvent from '@utils/registDragEvent';
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import * as styles from './curationCarousel.css';
 
@@ -12,13 +10,6 @@ const CurationCarousel = () => {
     itemCount: CURATION_INFO.length,
     moveDistance: 295,
   });
-
-  const navigate = useNavigate();
-
-  const handleClick = (index: number) => {
-    navigate(`/curation/${index + 1}`);
-    window.scrollTo(0, 0);
-  };
 
   return (
     <section ref={carouselRef} className={styles.carouselWrapper}>
@@ -36,7 +27,7 @@ const CurationCarousel = () => {
             bgImage={data.bgImage}
             title={data.title}
             subtitle={data.subtitle}
-            onClick={() => handleClick(index)}
+            link={`/curation/${index + 1}`}
           />
         ))}
       </div>

--- a/src/components/carousel/popularCarousel/PopularCarousel.tsx
+++ b/src/components/carousel/popularCarousel/PopularCarousel.tsx
@@ -6,8 +6,6 @@ import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
 import useCarousel from '@hooks/useCarousel';
 import { useQueryClient } from '@tanstack/react-query';
 import registDragEvent from '@utils/registDragEvent';
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import * as styles from './popularCarousel.css';
 
@@ -29,8 +27,6 @@ const PopularCarousel = ({ onRequireLogin }: PopularCarouselProps) => {
       itemCount: data?.rankings?.length || 0,
       moveDistance: 355,
     });
-
-  const navigate = useNavigate();
 
   if (isLoading) {
     return <ExceptLayout type="loading" />;
@@ -78,8 +74,8 @@ const PopularCarousel = ({ onRequireLogin }: PopularCarouselProps) => {
                 templeImg={rankings.imgUrl}
                 isLiked={rankings.liked}
                 tag={rankings.tag}
-                onClick={() => navigate(`/detail/${rankings.templestayId}`)}
                 onLikeToggle={(liked: boolean) => handleLikeToggle(rankings.templestayId, liked)}
+                link={`/detail/${rankings.templestayId}`}
               />
             ))}
         </div>

--- a/src/components/curation/curationCard/CurationCard.tsx
+++ b/src/components/curation/curationCard/CurationCard.tsx
@@ -4,20 +4,17 @@ interface CurationCardProps {
   bgImage: string;
   title: string;
   subtitle: string;
-  onClick: () => void;
+  link: string;
 }
 
-const CurationCard = ({ bgImage, title, subtitle, onClick }: CurationCardProps) => {
+const CurationCard = ({ bgImage, title, subtitle, link }: CurationCardProps) => {
   return (
-    <button
-      className={styles.cardContainer}
-      style={{ backgroundImage: `url(${bgImage})` }}
-      onClick={onClick}>
+    <a href={link} className={styles.cardContainer} style={{ backgroundImage: `url(${bgImage})` }}>
       <div className={styles.textbox}>
         <p className={styles.title}>{title}</p>
         <p className={styles.subtitle}>{subtitle}</p>
       </div>
-    </button>
+    </a>
   );
 };
 

--- a/src/components/detailTitle/DetailTitle.tsx
+++ b/src/components/detailTitle/DetailTitle.tsx
@@ -19,7 +19,7 @@ const DetailTitle = ({
 }: DetailTitleProps) => {
   return (
     <div className={titleContainerStyle}>
-      <p className={titleStyle({ size })}>{title}</p>
+      <h2 className={titleStyle({ size })}>{title}</h2>
       {isTotal && (
         <button className={buttonStyle} onClick={onClick} disabled={rightBtnDisabled}>
           {rigntBtnLabel}

--- a/src/pages/wishList/WishListPage.tsx
+++ b/src/pages/wishList/WishListPage.tsx
@@ -6,7 +6,6 @@ import Pagination from '@components/common/pagination/Pagination';
 import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import * as styles from './wishListPage.css';
 
@@ -14,7 +13,6 @@ const WishListPage = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const userId = Number(localStorage.getItem('userId'));
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
 
   const { data, isLoading, isError } = useWishlistQuery(currentPage, userId);
   const addWishlistMutation = useAddWishlist();
@@ -64,10 +62,6 @@ const WishListPage = () => {
     }
   };
 
-  const handleNavigate = (templestayId: number) => {
-    navigate(`/detail/${templestayId}`);
-  };
-
   if (isLoading) {
     return <ExceptLayout type="loading" />;
   }
@@ -91,7 +85,6 @@ const WishListPage = () => {
               data={wishlist}
               layout="vertical"
               onToggleWishlist={handleToggleWishlist}
-              onClick={(templestayId: number) => handleNavigate(templestayId)}
             />
           </div>
           <Pagination

--- a/src/stories/CurationCard.stories.ts
+++ b/src/stories/CurationCard.stories.ts
@@ -18,15 +18,12 @@ const meta = {
     subtitle: {
       control: { type: 'text' },
     },
-    onClick: {
-      action: 'clicked',
-    },
   },
   args: {
     bgImage: 'https://img.danawa.com/images/descFiles/6/110/5109431_agiLaciMHn_1659098198501.jpeg',
     title: '고양이 있는 절 봤어?',
     subtitle: '용문사에 있는 고양이 좀 봐. 귀엽지?',
-    onClick: () => alert('click !'),
+    link: 'https://www.gototemplestay.com/',
   },
 } satisfies Meta<typeof CurationCard>;
 

--- a/src/stories/PopularCard.stories.ts
+++ b/src/stories/PopularCard.stories.ts
@@ -24,9 +24,7 @@ const meta = {
     tag: {
       control: { type: 'text' },
     },
-    onClick: {
-      action: 'clicked',
-    },
+
     isLiked: {
       control: { type: 'boolean' },
     },
@@ -41,7 +39,7 @@ const meta = {
     templeImg:
       'https://img.danawa.com/images/descFiles/6/110/5109431_agiLaciMHn_1659098198501.jpeg',
     tag: '방긋방긋',
-    onClick: () => alert('click !'),
+    link: 'https://www.gototemplestay.com/',
     isLiked: false,
     onLikeToggle: () => alert('Liked'),
   },

--- a/src/stories/TempleStayCard.stories.ts
+++ b/src/stories/TempleStayCard.stories.ts
@@ -55,6 +55,7 @@ const meta = {
     layout: 'horizontal',
     onToggleWishlist: (templestayId: number, liked: boolean) =>
       alert(`Wishlist ${templestayId}: ${liked}`),
+    link: 'https://www.gototemplestay.com/',
   },
 } satisfies Meta<typeof TempleStayCard>;
 


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #245

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- robots.txt 파일을 추가하였습니다.
  - 모든 검색엔진봇을 허용 (`User-agent: *`) 
  - 검색 엔진 색인 제외 페이지 (login, loginStart 등등)
  - sitemap 추가
- sitemap.xml 파일을 추가하였습니다. 
  - 해당 파일은 www.xml-sitemaps.com를 통해 만들었고 현재는 메인페이지에 대한 sitemap만을 추가해두었습니다. 추후에 다른 페이지에 대한 추가도 필요할 것으로 보입니다.
  - header 시맨틱 태그가 기존에(main페이지에 한해서) 사진과 같이 h1없이 h2로 원하는 지역을 골라보세요가 헤더로 되어 있어서 해당 부분을 
<img width="250" alt="image" src="https://github.com/user-attachments/assets/48eaa375-22a7-423c-966b-05cd943a0d16" />

아래와 같이 header 시맨틱 태그를 부여하였습니다.
<img width="250" alt="image" src="https://github.com/user-attachments/assets/6893111b-cb0d-4670-b6ff-d88e8d997e2d" />

- PopularCard와 CurationCard에에서 `<a>` 태그 적용하여 SEO 및 접근성 개선
  - onClick 이벤트로 처리되던 네비게이션 로직을 href 속성으로 대체하여 SEO 친화적인 링크 구조 구현
  - 이전의 코드는  div 및 button이 클릭 이벤트를 감지하는 방식이라 검색 엔진이 이 카드가 링크인지 인식하지 못한다는 점을 개선하고자 하였습니다.


## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- 기존에 저희 코드에서 링크의 이동인 경우에도 `button`또는 `div`태그에 `onClick` `naviagte`를 이용하여 `button`을 링크처럼 사용해왔었습니다. 하지만 이는 검색 엔진이 버튼이 링크 역할을 한다는 것을 인식하지 못하여 페이지간의 연결이 제대로 이루어지지 않는다는 것을 알게되었습니다. 따라서 페이지 이동을 담당하는 버튼을 <a> 태그로 교체하여 검색 엔진이 사이트 구조를 더 잘 이해하도록 수정하고자 하였습니다. 아직 해당 작업이 필요한 부분이 더욱 많은 것으로 보입니다!
- 결국 웹이란 a태그로 연결된 문서들이며 해당 문서들을 잘 연결해서 검색 인덱싱이 잘 이루어져야 한다는 것에 대해서 고민해볼 수 있었습니다.
- SEO 관점에서 <a> 태그를 사용하면  검색 엔진이 링크를 따라 크롤링하며 페이지 관계를 올바르게 인식할 수 있어서 링크 구조를 명확하게 전달하므로 페이지 간 연결을 더 잘 이해하고 이로 인해서 검색 결과에서 더 나은 색인을 기대할 수 있음을 알게되었습니다. 
- 추가적으로 <a> 태그를 사용하면 사용자가 우클릭시 새 탭에서 열기와 같은 기능이 가능하기에 UX 개선 효과도 있음.
-  ### **결론 : 페이지 이동 `<a> 태그`, 페이지 이동이 아닌, 특정 기능(이벤트 트리거)이 필요한 경우 `<button> 태그`**

- robots.txt는 웹사이트에서 크롤링하며 정보를 수집하는 검색엔진 크롤러가 액세스 하거나 정보수집을 해도 되는 페이지가 무엇인지, 해서는 안 되는 페이지가 무엇인지 알려주는 역할을 하는 파일이라는 것을 알게되었습니다.
- 사이트맵은 웹사이트의 페이지 구조를 검색 엔진과 사용자에게 알려주는 텍스트라는 것을 알게되었습니다.

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- https://brunch.co.kr/@webbible/5
- https://seo.tbwakorea.com/blog/robots-txt-complete-guide/
- https://velog.io/@yena1025/SEO-robots.txt%EC%99%80-sitemap.xml%EC%97%90-%EB%8C%80%ED%95%98%EC%97%AC

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->