### PR TITLE
[REFACTOR] 로그인 리팩토링

### DIFF
--- a/src/apis/auth/axios.ts
+++ b/src/apis/auth/axios.ts
@@ -1,10 +1,9 @@
 import instance, { privateInstance } from '@apis/instance';
 
-export const getKakaoLogin = async (code: string) => {
-  const res = await instance.get('/login', {
-    params: {
-      code: code,
-    },
+export const postKakaoLogin = async (code: string, redirectUri: string) => {
+  const res = await instance.post('/login', {
+    code: code,
+    redirectUri: redirectUri,
   });
 
   return res;

--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -1,12 +1,13 @@
-import { getKakaoLogin, postLogout } from '@apis/auth/axios';
+import { postKakaoLogin, postLogout } from '@apis/auth/axios';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
-export const useGetKakaoLogin = () => {
+export const usePostKakaoLogin = () => {
   const navigate = useNavigate();
 
   return useMutation({
-    mutationFn: (authCode: string) => getKakaoLogin(authCode),
+    mutationFn: ({ code, redirectUri }: { code: string; redirectUri: string }) =>
+      postKakaoLogin(code, redirectUri),
     onSuccess: (response) => {
       const userId = response.data.userId;
       const accessToken = response.headers['authorization'].replace('Bearer ', '');

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -24,7 +24,7 @@ export const privateInstance = axios.create({
 
 export const postRefreshToken = async () => {
   try {
-    const response = await axios.get(`${API_URL}/auth/refresh`, {
+    const response = await axios.get(`${API_URL}/login/refresh`, {
       headers: {
         'Content-Type': 'application/json',
         refreshToken: localStorage.getItem('refreshToken'),

--- a/src/pages/RedirectionPage/RedirectionPage.tsx
+++ b/src/pages/RedirectionPage/RedirectionPage.tsx
@@ -1,17 +1,18 @@
-import { useGetKakaoLogin } from '@apis/auth';
+import { usePostKakaoLogin } from '@apis/auth';
 import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
 import React, { useEffect } from 'react';
 
 const RedirectionPage = () => {
   const code: string = new URL(window.location.href).searchParams.get('code') || '';
+  const redirectUri = `${import.meta.env.VITE_REDIRECT_URI}`;
 
   window.history.forward();
 
-  const { mutate } = useGetKakaoLogin();
+  const { mutate } = usePostKakaoLogin();
 
   useEffect(() => {
-    if (code) mutate(code);
-  }, [code, mutate]);
+    if (code) mutate({ code, redirectUri });
+  }, [code, redirectUri, mutate]);
 
   return <ExceptLayout type="loading" />;
 };


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #244 

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 로그인 API 수정사항에 맞춰 코드 리팩토링을 진행하였습니다. 

🛠️ 작업 목록

- 로그인 get -> post 수정 및 redirectUri 필드 추가
- accessToken 재발급 엔드포인트 수정

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 서버 측 요청에 따라 로그인 요청을 보낼 때 redirectUri도 함께 보내도록 수정했습니다. 해당 부분에서 고정된 값(redirectUri)을 클라 측에서 로그인 할 때마다 보내주어야 할 필요가 있는가 ? 에 대해 의문이 들어 서버 측에 여쭤봤는데, 로컬, 배포환경일 때마다 yml 파일을 변경해야 하는 번거로움이 있어 클라에서 redirectUri를 직접 전달하는 방식으로 수정하였다고 합니다 ~! 참고하세염
- 로그인 잘 되는지 테스트 한 번씩만 해주세요 !!!!!! (_ _)
## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- 

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->

https://github.com/user-attachments/assets/f668420f-d0d9-4f1b-b0af-9e72df455efe

