### PR TITLE
[CI/CD] vercel preview 배포 전용 workflow 추가

### DIFF
--- a/.github/workflows/auto-sync.yml
+++ b/.github/workflows/auto-sync.yml
@@ -8,12 +8,13 @@ on:
   pull_request:
     branches:
       - develop
+  workflow_dispatch: # 수동 실행도 가능하도록 추가
 
 jobs:
   sync_main:
     name: Sync forked repository on push to main
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.repository == 'JEOLLOGA/JEOLLOGA-CLIENT' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -50,7 +51,7 @@ jobs:
   sync_develop:
     name: Sync forked repository on push to develop
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    if: github.repository == 'JEOLLOGA/JEOLLOGA-CLIENT' && github.event_name == 'push' && github.ref == 'refs/heads/develop'
     steps:
       - name: Checkout develop
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -4,12 +4,13 @@ on:
   push:
     branches:
       - develop
+  workflow_dispatch: # 수동 실행도 가능하도록 추가
 
 jobs:
   deploy_preview:
     name: Deploy to Vercel (Preview)
     runs-on: ubuntu-latest
-    if: github.repository == 'seong-hui/JEOLLOGA-CLIENT'
+    if: github.repository == 'seong-hui/JEOLLOGA-CLIENT' && github.event_name == 'push' && github.ref == 'refs/heads/develop'
     steps:
       - name: Checkout develop
         uses: actions/checkout@v4

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -1,0 +1,21 @@
+name: Deploy Preview to Vercel
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  deploy_preview:
+    name: Deploy to Vercel (Preview)
+    runs-on: ubuntu-latest
+    if: github.repository == 'seong-hui/JEOLLOGA-CLIENT'
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel
+
+      - name: Deploy to Vercel (Preview)
+        run: vercel --token=${{ secrets.VERCEL_TOKEN }} --prod=false --yes


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #250

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 현재 develop브랜치에 push할시 fork된 브랜치로 동기화는 잘 일어나지만 vercel 배포는 일어나지 않아서 이를 해결하고자 vercel preview 배포 전용 workflow 추가하였습니다.
- 해당 workflow의 내용은 fork된 레파지토리에서 develop브랜치의 push가 일어날 시 Vercel Preview 배포가 자동 실행되게 하는 workflow입니다.
<img width="899" alt="image" src="https://github.com/user-attachments/assets/6ea39d73-ccc3-4d73-b611-51f25b6f78be" />

```
Auto-assign Custom Production Domains
Automatically assign custom domains after each deployment triggered by a merge to the production branch or a Vercel CLI deploy with the --prod flag.
```
해당 내용은 production 브랜치에 머지되거나 vercel --prod명령어를 통해 배포될때는 vercel이 설정된 커스텀 도메인을 자동으로 적용한다는 의미 입니다. 이를 통해서 preview 배포의 경우 직접 배포를 트리거해주면 자동 배포가 일어나지 않을까 생각하여 해당 workflow를 추가하게 되었습니다.

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- 

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->