### PR TITLE
[CI/CD] preview vercel 배포 cicd 깨짐 이슈 해결

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -20,3 +20,6 @@ jobs:
 
       - name: Deploy to Vercel (Preview)
         run: vercel --token=${{ secrets.VERCEL_TOKEN }} --prod=false --yes
+
+      - name: Assign Custom Preview Domain
+        run: vercel alias set dev-gototemplestay.vercel.app --token=${{ secrets.VERCEL_TOKEN }}

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,4 @@
 {
+  "name": "web-jeolloga",
   "rewrites": [{ "source": "/(.*)", "destination": "/" }]
 }


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #253

## 발생했던 오류
<img width="1009" alt="image" src="https://github.com/user-attachments/assets/9768820d-5b34-418d-83d5-1a8d94bc2ca0" />

```
Error: Project names can be up to 100 characters long and must be lowercase. 
They can include letters, digits, and the following characters: '.', '_', '-'. 
However, they cannot contain the sequence '---'. (400)
```

해당 오류의 내용은  한마디로`Vercel 프로젝트 이름에 문제가 있음!` 이에요. 하지만 실제 vercel프로젝트 이름에는 에러가 없었기 때문에 vercel 프로젝트의 이름을 명확하게 지정하는 방법을 택했습니다.

- vercel 프로젝트의 이름을 명확하게 지정하기 위해서  vercel.json 파일에서 "name" 속성을 추가했어요
  - 특히, GitHub Actions에서 자동 배포할 때 프로젝트를 찾기 쉽게 하기 위해 추가했어요/
  - vercel cli를 실행할 때 프로젝트를 자동 감지하려고 하지만 vercel.json에 "name"을 추가하면 CLI가 자동으로 프로젝트를 보다 정확히 인식할 수 있다고 해요!
  - 해당 방법으로 위의 에러를 해결했어요 

- 추가적으로 
```
 name: Assign Custom Preview Domain
        run: vercel alias set dev-gototemplestay.vercel.app --token=${{ secrets.VERCEL_TOKEN }}
```
해당 workflow를 추가해서 dev-gototemplestay.vercel.app을 항상 고정된 커스텀 도메인에 연결될 수 있도록 해주었어요!