### PR TITLE
[CI/CD] preview가 아닌 production으로 배포되는 문제 해결하기

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -19,7 +19,7 @@ jobs:
         run: npm install -g vercel
 
       - name: Deploy to Vercel (Preview)
-        run: vercel --token=${{ secrets.VERCEL_TOKEN }} --prod=false --yes
+        run: vercel --token=${{ secrets.VERCEL_TOKEN }} --target=preview --yes
 
       - name: Assign Custom Preview Domain
         run: vercel alias set dev-gototemplestay.vercel.app --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #256

## 🧑‍💻 문제 상황
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- develop브랜치로 push한 경우 preview 배포가 이루어진다고 생각했지만 sorce는 develop가 맞아도 계속해서 develop으로부터 production환경으로 배포가 진행되는 문제가 있었습니다.
<img width="600" alt="image" src="https://github.com/user-attachments/assets/add3de3d-ebd7-4814-a23f-d9a220f1bce3" />

- Preview 환경으로 배포하기 위해 기존에 사용한 코드는 다음과 같습니다.

```
 run: vercel --token=${{ secrets.VERCEL_TOKEN }} --prod=false --yes
```
- `--prod=false`를 사용하면 Preview 배포가 이루어진다고 생각했으나 실제로는 계속 Production 환경으로 배포되었어요.(지피티가 이렇게 하면 된다고 해서 이렇게 넣었던 저를 반성합니다.)
- 문제를 해결하기 위해 Vercel CLI 공식 문서를 확인한 결과,  아래와 같이 `--target` 옵션을 사용하면 배포할 환경을 지정할 수 있다는 설명이 있었습니다. 
<img width="600" alt="image" src="https://github.com/user-attachments/assets/f33a7213-aaf3-43d8-a53e-ff737f902fe6" />

```
Use the --target option to define the environment you want to deploy to. This could be production, preview, or a custom environment.
```

## 해결 방법
- `--prod=false `대신 `--target=preview`를 사용하여 Preview 환경으로 명확하게 배포하도록 수정했어요!
-  다음과 같이 수정
```
 run: vercel --token=${{ secrets.VERCEL_TOKEN }} --target=preview --yes
```

- 이를 fork된 제 레포에서 테스트해본 결과 Preview 환경으로 정상 배포되는 것을 확인했습니다.
<img width="600" alt="image" src="https://github.com/user-attachments/assets/ff4ca22a-1317-400c-8c2d-b7df97afeed2" />


## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- https://vercel.com/docs/cli/deploy#target
