### PR TITLE
[FEAT] 검색어 개별 삭제 api 연결 및 검색 로직 수정

### DIFF
--- a/src/components/common/button/basicBtn/BasicBtn.tsx
+++ b/src/components/common/button/basicBtn/BasicBtn.tsx
@@ -8,6 +8,7 @@ interface ButtonProps {
   leftIcon?: keyof typeof Icon;
   rightIcon?: keyof typeof Icon;
   onClick?: () => void;
+  onRightIconClick?: () => void;
   isActive?: boolean;
 }
 
@@ -18,6 +19,7 @@ const BasicBtn = ({
   leftIcon,
   rightIcon,
   onClick,
+  onRightIconClick,
   isActive = false,
 }: ButtonProps) => {
   const SelectedLeftIcon = leftIcon ? Icon[leftIcon] : null;
@@ -29,7 +31,18 @@ const BasicBtn = ({
       onClick={onClick}>
       {SelectedLeftIcon && <SelectedLeftIcon />}
       <p>{label}</p>
-      {SelectedRightIcon && <SelectedRightIcon />}
+      {SelectedRightIcon && (
+        <button
+          onClick={
+            onRightIconClick &&
+            ((e) => {
+              e.stopPropagation();
+              onRightIconClick();
+            })
+          }>
+          <SelectedRightIcon />
+        </button>
+      )}
     </button>
   );
 };

--- a/src/components/search/recentBtn/RecentBtnBox.tsx
+++ b/src/components/search/recentBtn/RecentBtnBox.tsx
@@ -1,4 +1,4 @@
-import { useGetSearchHistory, useDelAllSearchRecord } from '@apis/search';
+import { useGetSearchHistory, useDelAllSearchRecord, useDelSearchRecord } from '@apis/search';
 import { Content } from '@apis/search/type';
 import BasicBtn from '@components/common/button/basicBtn/BasicBtn';
 import DetailTitle from '@components/detailTitle/DetailTitle';
@@ -11,6 +11,7 @@ const RecentBtnBox = () => {
   const userId = localStorage.getItem('userId');
   const { data, isLoading, isError, refetch } = useGetSearchHistory(userId ? Number(userId) : null);
   const { mutate: deleteAllSearchRecords } = useDelAllSearchRecord();
+  const { mutate: deleteSearchRecord } = useDelSearchRecord();
   const { handleSearch } = useFilter();
 
   const [searchData, setSearchData] = useState<Content[]>([]);
@@ -49,6 +50,10 @@ const RecentBtnBox = () => {
     handleSearch(searchContent);
   };
 
+  const handleDeleteSearch = (searchId: number) => {
+    deleteSearchRecord({ userId: Number(userId), searchId });
+  };
+
   if (isLoading) {
     return <ExceptLayout type="loading" />;
   }
@@ -78,7 +83,9 @@ const RecentBtnBox = () => {
               label={item.content}
               variant="lightGrayOutlined"
               size="small"
+              rightIcon="IcnCloseSmallGray"
               onClick={() => handleRecentSearchClick(item.content)} // 검색어 클릭 이벤트
+              onRightIconClick={() => handleDeleteSearch(item.searchId)}
             />
           ))
         )}

--- a/src/components/search/recentBtn/RecentBtnBox.tsx
+++ b/src/components/search/recentBtn/RecentBtnBox.tsx
@@ -5,6 +5,7 @@ import DetailTitle from '@components/detailTitle/DetailTitle';
 import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
 import * as styles from '@components/search/recentBtn/recentBtnBox.css';
 import useFilter from '@hooks/useFilter';
+import useLocalStorage from '@hooks/useLocalStorage';
 import { useState, useEffect } from 'react';
 
 const RecentBtnBox = () => {
@@ -13,13 +14,14 @@ const RecentBtnBox = () => {
   const { mutate: deleteAllSearchRecords } = useDelAllSearchRecord();
   const { mutate: deleteSearchRecord } = useDelSearchRecord();
   const { handleSearch } = useFilter();
+  const { getStorageValue, delSearchHistory } = useLocalStorage();
 
   const [searchData, setSearchData] = useState<Content[]>([]);
 
   useEffect(() => {
     if (!userId) {
-      const localSearchHistory = JSON.parse(localStorage.getItem('searchHistory') || '[]');
-      setSearchData(Array.isArray(localSearchHistory) ? localSearchHistory : []);
+      const searchHistory = getStorageValue('searchHistory');
+      setSearchData(Array.isArray(searchHistory) ? searchHistory : []);
     } else if (data) {
       setSearchData(Array.isArray(data.searchHistory) ? data.searchHistory : []);
     }
@@ -42,14 +44,7 @@ const RecentBtnBox = () => {
     if (userId) {
       deleteSearchRecord({ userId: Number(userId), searchId });
     } else {
-      const searchHistory: { searchId: number; content: string }[] = JSON.parse(
-        localStorage.getItem('searchHistory') || '[]',
-      );
-
-      localStorage.setItem(
-        'searchHistory',
-        JSON.stringify(searchHistory.filter((item) => item.searchId !== searchId)),
-      );
+      delSearchHistory(searchId);
     }
   };
 

--- a/src/components/search/recentBtn/RecentBtnBox.tsx
+++ b/src/components/search/recentBtn/RecentBtnBox.tsx
@@ -6,7 +6,6 @@ import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
 import * as styles from '@components/search/recentBtn/recentBtnBox.css';
 import useFilter from '@hooks/useFilter';
 import useLocalStorage from '@hooks/useLocalStorage';
-import { useState, useEffect } from 'react';
 
 const RecentBtnBox = () => {
   const userId = localStorage.getItem('userId');
@@ -14,25 +13,16 @@ const RecentBtnBox = () => {
   const { mutate: deleteAllSearchRecords } = useDelAllSearchRecord();
   const { mutate: deleteSearchRecord } = useDelSearchRecord();
   const { handleSearch } = useFilter();
-  const { getStorageValue, delSearchHistory } = useLocalStorage();
+  const { searchHistory, delSearchHistory, setSearchHistory } = useLocalStorage();
 
-  const [searchData, setSearchData] = useState<Content[]>([]);
-
-  useEffect(() => {
-    if (!userId) {
-      const searchHistory = getStorageValue('searchHistory');
-      setSearchData(Array.isArray(searchHistory) ? searchHistory : []);
-    } else if (data) {
-      setSearchData(Array.isArray(data.searchHistory) ? data.searchHistory : []);
-    }
-  }, [data, userId]);
+  const searchData: Content[] = userId ? data?.searchHistory || [] : searchHistory;
 
   const handleDeleteAll = () => {
     if (userId) {
       deleteAllSearchRecords({ userId: Number(userId) });
     } else {
       localStorage.removeItem('searchHistory');
-      setSearchData([]);
+      setSearchHistory([]);
     }
   };
 
@@ -55,6 +45,7 @@ const RecentBtnBox = () => {
   if (isError) {
     return <ExceptLayout type="networkError" />;
   }
+
   return (
     <section>
       <div className={styles.paddingStyle}>

--- a/src/components/search/recentBtn/RecentBtnBox.tsx
+++ b/src/components/search/recentBtn/RecentBtnBox.tsx
@@ -9,7 +9,7 @@ import { useState, useEffect } from 'react';
 
 const RecentBtnBox = () => {
   const userId = localStorage.getItem('userId');
-  const { data, isLoading, isError, refetch } = useGetSearchHistory(userId ? Number(userId) : null);
+  const { data, isLoading, isError } = useGetSearchHistory(userId ? Number(userId) : null);
   const { mutate: deleteAllSearchRecords } = useDelAllSearchRecord();
   const { mutate: deleteSearchRecord } = useDelSearchRecord();
   const { handleSearch } = useFilter();
@@ -25,18 +25,6 @@ const RecentBtnBox = () => {
     }
   }, [data, userId]);
 
-  // 뒤로 가기 이벤트 처리
-  useEffect(() => {
-    const handlePopState = () => {
-      refetch(); // 뒤로 가기 시 데이터 갱신
-    };
-
-    window.addEventListener('popstate', handlePopState);
-    return () => {
-      window.removeEventListener('popstate', handlePopState);
-    };
-  }, [refetch]);
-
   const handleDeleteAll = () => {
     if (userId) {
       deleteAllSearchRecords({ userId: Number(userId) });
@@ -51,7 +39,18 @@ const RecentBtnBox = () => {
   };
 
   const handleDeleteSearch = (searchId: number) => {
-    deleteSearchRecord({ userId: Number(userId), searchId });
+    if (userId) {
+      deleteSearchRecord({ userId: Number(userId), searchId });
+    } else {
+      const searchHistory: { searchId: number; content: string }[] = JSON.parse(
+        localStorage.getItem('searchHistory') || '[]',
+      );
+
+      localStorage.setItem(
+        'searchHistory',
+        JSON.stringify(searchHistory.filter((item) => item.searchId !== searchId)),
+      );
+    }
   };
 
   if (isLoading) {

--- a/src/hooks/useCarousel.ts
+++ b/src/hooks/useCarousel.ts
@@ -21,7 +21,6 @@ const useCarousel = ({ itemCount, moveDistance }: UseCarouselProps) => {
       // 왼쪽으로 드래그
       setCurrentIndex(currentIndex + 1 > maxIndex ? maxIndex : currentIndex + 1);
     } else if (deltaX > 85) {
-
       // 오른쪽으로 드래그
       setCurrentIndex(currentIndex - 1 < 0 ? 0 : currentIndex - 1);
     }

--- a/src/hooks/useFilter.ts
+++ b/src/hooks/useFilter.ts
@@ -77,21 +77,17 @@ const useFilter = () => {
       // 로그인 안 한 사용자의 경우 검색어를 로컬스토리지에 저장
       if (!isLoggedIn) {
         if (searchQuery.trim() !== '') {
-          const searchHistory = JSON.parse(localStorage.getItem('searchHistory') || '[]');
+          const searchHistory: { searchId: number; content: string }[] = JSON.parse(
+            localStorage.getItem('searchHistory') || '[]',
+          );
 
-          const newRecord = {
-            searchId: new Date().getTime(),
-            content: searchQuery,
-          };
+          // 중복된 검색어는 저장 안 하도록, 최대 10개까지만
+          const updatedHistory = [
+            { searchId: new Date().getTime(), content: searchQuery },
+            ...searchHistory.filter((item) => item.content !== searchQuery),
+          ].slice(0, 10);
 
-          searchHistory.unshift(newRecord); // 배열 맨 앞에 추가
-
-          // 최대 10개까지 저장
-          if (searchHistory.length > 10) {
-            searchHistory.pop();
-          }
-
-          localStorage.setItem('searchHistory', JSON.stringify(searchHistory));
+          localStorage.setItem('searchHistory', JSON.stringify(updatedHistory));
         }
       }
 

--- a/src/hooks/useFilter.ts
+++ b/src/hooks/useFilter.ts
@@ -79,20 +79,19 @@ const useFilter = () => {
         if (searchQuery.trim() !== '') {
           const searchHistory = JSON.parse(localStorage.getItem('searchHistory') || '[]');
 
-          // Set을 사용하여 중복된 검색어를 제거
-          const searchHistorySet = new Set([
-            searchQuery,
-            ...searchHistory.map((item: { content: string }) => item.content),
-          ]);
+          const newRecord = {
+            searchId: new Date().getTime(),
+            content: searchQuery,
+          };
 
-          const updatedHistory = Array.from(searchHistorySet)
-            .slice(0, 10)
-            .map((content) => ({
-              searchId: new Date().getTime(),
-              content,
-            }));
+          searchHistory.unshift(newRecord); // 배열 맨 앞에 추가
 
-          localStorage.setItem('searchHistory', JSON.stringify(updatedHistory));
+          // 최대 10개까지 저장
+          if (searchHistory.length > 10) {
+            searchHistory.pop();
+          }
+
+          localStorage.setItem('searchHistory', JSON.stringify(searchHistory));
         }
       }
 

--- a/src/hooks/useFilter.ts
+++ b/src/hooks/useFilter.ts
@@ -1,5 +1,6 @@
 import useFetchFilteredList from '@apis/filter';
 import { fetchFilteredCount } from '@apis/filter/axios';
+import useLocalStorage from '@hooks/useLocalStorage';
 import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import { useAtom } from 'jotai';
 import { useNavigate } from 'react-router-dom';
@@ -55,6 +56,8 @@ const useFilter = () => {
 
   const getUserId = () => localStorage.getItem('userId') || '';
 
+  const { setSearchHistory } = useLocalStorage();
+
   // 검색 실행 함수
   const handleSearch = async (searchContent?: string, currentPage = 1) => {
     const groupedFilters = getGroupedFilters();
@@ -75,20 +78,8 @@ const useFilter = () => {
       setContent(searchQuery);
 
       // 로그인 안 한 사용자의 경우 검색어를 로컬스토리지에 저장
-      if (!isLoggedIn) {
-        if (searchQuery.trim() !== '') {
-          const searchHistory: { searchId: number; content: string }[] = JSON.parse(
-            localStorage.getItem('searchHistory') || '[]',
-          );
-
-          // 중복된 검색어는 저장 안 하도록, 최대 10개까지만
-          const updatedHistory = [
-            { searchId: new Date().getTime(), content: searchQuery },
-            ...searchHistory.filter((item) => item.content !== searchQuery),
-          ].slice(0, 10);
-
-          localStorage.setItem('searchHistory', JSON.stringify(updatedHistory));
-        }
+      if (!isLoggedIn && searchQuery.trim() !== '') {
+        setSearchHistory(searchQuery);
       }
 
       window.scrollTo({ top: 0, behavior: 'smooth' });

--- a/src/hooks/useFilter.ts
+++ b/src/hooks/useFilter.ts
@@ -64,7 +64,7 @@ const useFilter = () => {
     const searchQuery = searchContent ? searchContent.replace(/\s+/g, '') : content;
     const adjustedPrice = getAdjustedPrice();
 
-    const isLoggedIn = localStorage.getItem('Authorzation');
+    const isLoggedIn = localStorage.getItem('Authorization');
 
     try {
       const response = await fetchFilterLists({

--- a/src/hooks/useFilter.ts
+++ b/src/hooks/useFilter.ts
@@ -56,7 +56,7 @@ const useFilter = () => {
 
   const getUserId = () => localStorage.getItem('userId') || '';
 
-  const { setSearchHistory } = useLocalStorage();
+  const { addSearchHistory } = useLocalStorage();
 
   // 검색 실행 함수
   const handleSearch = async (searchContent?: string, currentPage = 1) => {
@@ -79,7 +79,7 @@ const useFilter = () => {
 
       // 로그인 안 한 사용자의 경우 검색어를 로컬스토리지에 저장
       if (!isLoggedIn && searchQuery.trim() !== '') {
-        setSearchHistory(searchQuery);
+        addSearchHistory(searchQuery);
       }
 
       window.scrollTo({ top: 0, behavior: 'smooth' });

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,19 +1,29 @@
+import { useState } from 'react';
+
+interface SearchHistoryItem {
+  searchId: number;
+  content: string;
+}
+
 const useLocalStorage = () => {
   const getStorageValue = (key: string) => {
     const storedValue = localStorage.getItem(key);
     return storedValue ? JSON.parse(storedValue) : [];
   };
 
-  // 검색어 저장
-  const setSearchHistory = (searchQuery: string) => {
-    const searchHistory: { searchId: number; content: string }[] = getStorageValue('searchHistory');
+  const [searchHistory, setSearchHistory] = useState<SearchHistoryItem[]>(() => {
+    return getStorageValue('searchHistory');
+  });
 
+  // 검색어 저장
+  const addSearchHistory = (searchQuery: string) => {
     // 중복된 검색어는 저장 안 하도록, 최대 10개까지만
     const updatedHistory = [
       { searchId: new Date().getTime(), content: searchQuery },
       ...searchHistory.filter((item) => item.content !== searchQuery),
     ].slice(0, 10);
 
+    setSearchHistory(updatedHistory);
     localStorage.setItem('searchHistory', JSON.stringify(updatedHistory));
   };
 
@@ -22,10 +32,17 @@ const useLocalStorage = () => {
     const searchHistory: { searchId: number; content: string }[] = getStorageValue('searchHistory');
     const updatedHistory = searchHistory.filter((item) => item.searchId !== searchId);
 
+    setSearchHistory(updatedHistory);
     localStorage.setItem('searchHistory', JSON.stringify(updatedHistory));
   };
 
-  return { getStorageValue, setSearchHistory, delSearchHistory };
+  return {
+    searchHistory,
+    setSearchHistory,
+    getStorageValue,
+    addSearchHistory,
+    delSearchHistory,
+  };
 };
 
 export default useLocalStorage;

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,31 @@
+const useLocalStorage = () => {
+  const getStorageValue = (key: string) => {
+    const storedValue = localStorage.getItem(key);
+    return storedValue ? JSON.parse(storedValue) : [];
+  };
+
+  // 검색어 저장
+  const setSearchHistory = (searchQuery: string) => {
+    const searchHistory: { searchId: number; content: string }[] = getStorageValue('searchHistory');
+
+    // 중복된 검색어는 저장 안 하도록, 최대 10개까지만
+    const updatedHistory = [
+      { searchId: new Date().getTime(), content: searchQuery },
+      ...searchHistory.filter((item) => item.content !== searchQuery),
+    ].slice(0, 10);
+
+    localStorage.setItem('searchHistory', JSON.stringify(updatedHistory));
+  };
+
+  // 검색어 삭제
+  const delSearchHistory = (searchId: number) => {
+    const searchHistory: { searchId: number; content: string }[] = getStorageValue('searchHistory');
+    const updatedHistory = searchHistory.filter((item) => item.searchId !== searchId);
+
+    localStorage.setItem('searchHistory', JSON.stringify(updatedHistory));
+  };
+
+  return { getStorageValue, setSearchHistory, delSearchHistory };
+};
+
+export default useLocalStorage;

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 interface SearchHistoryItem {
   searchId: number;
@@ -15,12 +15,18 @@ const useLocalStorage = () => {
     return getStorageValue('searchHistory');
   });
 
+  useEffect(() => {
+    localStorage.setItem('searchHistory', JSON.stringify(searchHistory));
+  }, [searchHistory]);
+
   // 검색어 저장
   const addSearchHistory = (searchQuery: string) => {
     // 중복된 검색어는 저장 안 하도록, 최대 10개까지만
     const updatedHistory = [
       { searchId: new Date().getTime(), content: searchQuery },
-      ...searchHistory.filter((item) => item.content !== searchQuery),
+      ...getStorageValue('searchHistory').filter(
+        (item: SearchHistoryItem) => item.content !== searchQuery,
+      ),
     ].slice(0, 10);
 
     setSearchHistory(updatedHistory);


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #260 

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 검색어 개별 삭제 api 연결했습니다.
  - 최근 검색어 삭제 기능에서 검색어 클릭 시 재검색과 'x' 버튼 클릭 시 해당 검색어 삭제가 필요했습니다. 이를 위해 BasicBtn 컴포넌트에 SelectedRightIcon의 onClick을 처리할 수 있는 props를 추가했습니다.
 - 검색 로직 리팩토링 했습니당
   - 기존 코드의 문제점들(불필요한 useEffect, 로컬스토리지에 검색어 저장 시 searchId가 덮어써져 모든 항목이 같은 searchId를 갖게되는 오류) 수정하였습니다 !
   - 기존에는 handleSearch 함수 내에 로컬스토리지에 검색어를 저장하는 로직과 RecentBtnBox 컴포넌트 내에 검색어 삭제 로직이 위치해 있었습니다. 재사용 가능성이 높은 로직은 아니었지만, 각 로직을 별도로 분리하는 것이 더 깔끔할 것 같아 분리했습니다. 하나의 함수는 하나의 기능만 맡는 것이 좋다는 생각에 handleSearch 함수는 검색 실행만 담당하도록 하고, 로컬 스토리지에 검색어를 저장하는 로직과 삭제 로직은 별도의 `useLocalStorage.ts`에 작성하였습니다

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- useEffect로 로컬스토리지 동기화해주기 ~.~

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- [[React] LocalStorage 사용하기](https://velog.io/@ahsy92/React-LocalStorage-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0)

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->