### PR TITLE
[FIX] 템플스테이 카드 위시리스트 담기 클릭시 페이지 이동 막기 구현

### DIFF
--- a/src/components/card/popularCard/PopularCard.tsx
+++ b/src/components/card/popularCard/PopularCard.tsx
@@ -29,6 +29,7 @@ const PopularCard = ({
 
   const handleLikeClick = (e: React.MouseEvent) => {
     e.stopPropagation();
+    e.preventDefault();
 
     const userId = Number(localStorage.getItem('userId'));
     if (!userId) {

--- a/src/components/card/templeStayCard/TempleStayCard.tsx
+++ b/src/components/card/templeStayCard/TempleStayCard.tsx
@@ -39,6 +39,7 @@ const TempleStayCard = ({
 
   const onClickWishBtn = (e: React.MouseEvent) => {
     e.stopPropagation();
+    e.preventDefault();
 
     const userId = Number(localStorage.getItem('userId'));
     if (!userId) {


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #262 

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 템플스테이 카드 클릭 시 페이지 이동을 a태그로 바꾸면서, 위시리스트 담기 버튼을 클릭하는 경우 기존 e.stopPropagation();으로는 페이지 이동이 안 막아지던 문제를 e.preventDefault();를 추가하여 해결했습니다.

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- preventDefault()를 사용하면 a태그의 기본 동작(페이지 이동)이 차단된다.

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->