### PR TITLE
[FEAT] 탈퇴하기 api 연결

### DIFF
--- a/src/apis/auth/axios.ts
+++ b/src/apis/auth/axios.ts
@@ -14,3 +14,11 @@ export const postLogout = async () => {
 
   return res;
 };
+
+export const postWithdraw = async (userId: number | null) => {
+  const res = await instance.post('/login/unlink', {
+    userId: userId,
+  });
+
+  return res;
+};

--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -58,7 +58,6 @@ export const usePostWithdraw = ({ userId }: { userId: number | null }) => {
     onSuccess: () => {
       localStorage.clear();
       navigate('/');
-      window.location.reload();
     },
     onError: (error) => {
       console.error(error);

--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -1,4 +1,4 @@
-import { postKakaoLogin, postLogout } from '@apis/auth/axios';
+import { postKakaoLogin, postLogout, postWithdraw } from '@apis/auth/axios';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
@@ -41,6 +41,25 @@ export const usePostLogout = () => {
       navigate('/');
     },
 
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+};
+
+export const usePostWithdraw = ({ userId }: { userId: number | null }) => {
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: async () => {
+      if (!userId) throw new Error('Invalid userId');
+      return await postWithdraw(userId);
+    },
+    onSuccess: () => {
+      localStorage.clear();
+      navigate('/');
+      window.location.reload();
+    },
     onError: (error) => {
       console.error(error);
     },

--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -58,6 +58,7 @@ export const usePostWithdraw = ({ userId }: { userId: number | null }) => {
     onSuccess: () => {
       localStorage.clear();
       navigate('/');
+      window.location.reload();
     },
     onError: (error) => {
       console.error(error);

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -42,6 +42,10 @@ privateInstance.interceptors.response.use(
   (response) => response,
 
   async (error) => {
+    if (!localStorage.getItem('Authorization')) {
+      return Promise.reject(error);
+    }
+
     const {
       config,
       response: { status },
@@ -58,7 +62,6 @@ privateInstance.interceptors.response.use(
           localStorage.setItem('Authorization', parsedToken);
 
           axios.defaults.headers.common.Authorization = `Bearer ${parsedToken}`;
-          // 진행중이던 요청 이어서 하기
           originRequest.headers.Authorization = `Bearer ${parsedToken}`;
 
           return await axios(originRequest);
@@ -70,9 +73,7 @@ privateInstance.interceptors.response.use(
         window.location.replace('/');
       }
     }
-    if (!localStorage.getItem('Authorization')) {
-      return Promise.reject(error);
-    }
+    return Promise.reject(error);
   },
 );
 

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -70,7 +70,9 @@ privateInstance.interceptors.response.use(
         window.location.replace('/');
       }
     }
-    return Promise.reject(error);
+    if (!localStorage.getItem('Authorization')) {
+      return Promise.reject(error);
+    }
   },
 );
 

--- a/src/pages/myPage/MyPage.tsx
+++ b/src/pages/myPage/MyPage.tsx
@@ -1,4 +1,4 @@
-import { usePostLogout } from '@apis/auth';
+import { usePostLogout, usePostWithdraw } from '@apis/auth';
 import { useGetMyPage } from '@apis/user';
 import ModalContainer from '@components/common/modal/ModalContainer';
 import PageName from '@components/common/pageName/PageName';
@@ -12,9 +12,13 @@ import * as styles from './myPage.css';
 const MyPage = () => {
   const [isLogoutModalOpen, setIsLogoutModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const postLogout = usePostLogout();
 
   const userId = localStorage.getItem('userId') || '';
+  const parseUserId = userId ? parseInt(userId, 10) : null;
+
+  const postLogout = usePostLogout();
+  const postWithdraw = usePostWithdraw({ userId: parseUserId });
+
   const { data, isLoading, isError } = useGetMyPage(userId);
 
   const handleLogoutClick = () => {
@@ -31,8 +35,8 @@ const MyPage = () => {
   };
 
   const confirmDelete = () => {
-    window.open('https://www.notion.so/1847c7beb778804b975fedee8883552d?pvs=4');
-    setIsDeleteModalOpen(false);
+    postWithdraw.mutate();
+    setIsLogoutModalOpen(false);
   };
 
   if (isLoading) {


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #264 

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 탈퇴 api를 구현했습니다.

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 탈퇴 후 홈페이지로 돌아올 때 401 Unauthorized 응답이 발생하여 alert가 떴지만, Authorization이 없는 경우에는 401을 감지해도 추가적인 처리를 하지 않도록 수정하여, alert가 뜨지 않도록 했습니다.

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- 

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->
https://github.com/user-attachments/assets/8bb87d1e-c95e-4f4b-b02d-f3c5305189d6