### PR TITLE
[FEAT] GA 이벤트 태그 지정

### DIFF
--- a/src/components/card/lookCard/LookCard.tsx
+++ b/src/components/card/lookCard/LookCard.tsx
@@ -1,5 +1,6 @@
 import BasicBtn from '@components/common/button/basicBtn/BasicBtn';
 import useFilter from '@hooks/useFilter';
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 import * as styles from './lookCard.css';
 
@@ -8,7 +9,13 @@ interface LookCardProps {
 }
 
 const LookCard = ({ name = '일로와' }: LookCardProps) => {
+  const { logClickEvent } = useEventLogger('home_banner');
   const { handleSearch } = useFilter();
+
+  const handleClickBtn = () => {
+    handleSearch();
+    logClickEvent('click_templestay_detail');
+  };
 
   return (
     <section className={styles.cardWrapper}>
@@ -27,7 +34,7 @@ const LookCard = ({ name = '일로와' }: LookCardProps) => {
           </h1>
           <div>
             <BasicBtn
-              onClick={() => handleSearch()}
+              onClick={handleClickBtn}
               variant="green"
               label="둘러보기"
               size="large"

--- a/src/components/card/mapCard/Map.tsx
+++ b/src/components/card/mapCard/Map.tsx
@@ -1,14 +1,20 @@
 import LocBtn from '@components/card/mapCard/LocBtn';
 import mapStyle from '@components/card/mapCard/map.css';
-import REGION_INFOS from '@constants/regionInfos';
+import { REGION_INFOS, REGION_LABEL_MAP } from '@constants/regionInfos';
 import useFilter from '@hooks/useFilter';
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 const Map = () => {
   const { toggleFilter, handleSearch } = useFilter();
+  const { logClickEvent } = useEventLogger('home_map');
 
   const handleClickMap = async (region: string) => {
     await toggleFilter(region);
     handleSearch();
+
+    logClickEvent(`click_region_${REGION_LABEL_MAP[region]}`, {
+      label: region,
+    });
   };
 
   return (

--- a/src/components/card/templeStayCard/TempleStayCard.tsx
+++ b/src/components/card/templeStayCard/TempleStayCard.tsx
@@ -2,6 +2,7 @@ import errorImage from '@assets/images/img_gray_light_leaf_medium.png';
 import InfoSection from '@components/card/templeStayCard/InfoSection';
 import FlowerIcon from '@components/common/icon/flowerIcon/FlowerIcon';
 import { useState } from 'react';
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 import * as styles from './templeStayCard.css';
 
@@ -36,6 +37,7 @@ const TempleStayCard = ({
 }: TempleStayCardProps) => {
   const [isWished, setIsWished] = useState(liked);
   const isHorizontal = layout === 'horizontal';
+  const { logClickEvent } = useEventLogger('templestay_card');
 
   const onClickWishBtn = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -49,10 +51,14 @@ const TempleStayCard = ({
 
     setIsWished((prev) => !prev);
     onToggleWishlist(templestayId, isWished);
+    logClickEvent(`click_wish_${isWished ? 'remove' : 'add'}`, { label: templeName });
   };
 
   return (
-    <a href={link} className={isHorizontal ? styles.horizontalContainer : styles.verticalContainer}>
+    <a
+      href={link}
+      className={isHorizontal ? styles.horizontalContainer : styles.verticalContainer}
+      onClick={() => logClickEvent('click_card_detail')}>
       {imgUrl ? (
         <section className={isHorizontal ? styles.horizontalImgSection : styles.verticalImgSection}>
           <img

--- a/src/components/card/templeStayCard/TempleStayCard.tsx
+++ b/src/components/card/templeStayCard/TempleStayCard.tsx
@@ -2,6 +2,7 @@ import errorImage from '@assets/images/img_gray_light_leaf_medium.png';
 import InfoSection from '@components/card/templeStayCard/InfoSection';
 import FlowerIcon from '@components/common/icon/flowerIcon/FlowerIcon';
 import { useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 import * as styles from './templeStayCard.css';
@@ -38,6 +39,10 @@ const TempleStayCard = ({
   const [isWished, setIsWished] = useState(liked);
   const isHorizontal = layout === 'horizontal';
   const { logClickEvent } = useEventLogger('templestay_card');
+  const location = useLocation();
+
+  const isWishPage = location.pathname === '/wishList';
+  console.log(location.pathname);
 
   const onClickWishBtn = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -51,7 +56,10 @@ const TempleStayCard = ({
 
     setIsWished((prev) => !prev);
     onToggleWishlist(templestayId, isWished);
-    logClickEvent(`click_wish_${isWished ? 'remove' : 'add'}`, { label: templeName });
+    logClickEvent(`click_wish_${isWished ? 'remove' : 'add'}`, {
+      label: templeName,
+      screen: `${isWishPage ? 'wish' : 'templestay_card'}`,
+    });
   };
 
   return (

--- a/src/components/common/button/kakaoBtn/KakaoBtn.tsx
+++ b/src/components/common/button/kakaoBtn/KakaoBtn.tsx
@@ -1,11 +1,16 @@
 import Icon from '@assets/svgs';
 import loginBtn from '@components/common/button/kakaoBtn/kakaoBtn.css';
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 const KakaoBtn = () => {
+  const { logClickEvent } = useEventLogger('login_wish_page');
+
   const handleLogin = () => {
     window.location.href = `https://kauth.kakao.com/oauth/authorize?client_id=${
       import.meta.env.VITE_REST_API_KEY
     }&redirect_uri=${import.meta.env.VITE_REDIRECT_URI}&response_type=code`;
+
+    logClickEvent('click_login');
   };
 
   return (

--- a/src/components/common/empty/wishEmpty/WishEmpty.tsx
+++ b/src/components/common/empty/wishEmpty/WishEmpty.tsx
@@ -1,11 +1,13 @@
 import emptyImage from '@assets/images/img_gray_light_leaf_large.png';
 import PageBottomBtn from '@components/common/button/pageBottomBtn/PageBottomBtn';
 import useFilter from '@hooks/useFilter';
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 import * as styles from './wishEmpty.css';
 
 const WishEmpty = () => {
   const { handleSearch } = useFilter();
+  const { logClickEvent } = useEventLogger('wish_empty_page');
 
   return (
     <div className={styles.container}>
@@ -13,7 +15,14 @@ const WishEmpty = () => {
         <p className={styles.textStyle}>위시리스트가 비어있어요</p>
         <img src={emptyImage} alt="위시리스트 비어있음" />
       </div>
-      <PageBottomBtn btnText="템플스테이 둘러보기" size="small" onClick={() => handleSearch()} />
+      <PageBottomBtn
+        btnText="템플스테이 둘러보기"
+        size="small"
+        onClick={() => {
+          logClickEvent('click_templestay_detail');
+          handleSearch();
+        }}
+      />
     </div>
   );
 };

--- a/src/components/common/tapBar/TapBar.tsx
+++ b/src/components/common/tapBar/TapBar.tsx
@@ -6,6 +6,7 @@ import { TapType, TAPS } from '@constants/taps';
 import useMoveScroll from '@hooks/useMoveScroll';
 import useScrollTracker from '@hooks/useScrollTrack';
 import { useEffect } from 'react';
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 interface TapBarProps {
   type: TapType;
@@ -22,10 +23,22 @@ const TapBar = ({ type, selectedTap }: TapBarProps) => {
 
   const { scrollIndex, handleClick } = useScrollTracker(sectionIds, headerHeight);
   const scrollToElement = useMoveScroll(headerHeight);
+  const { logClickEvent } = useEventLogger('filter_tag');
 
   const handleTabClick = (index: number) => {
     handleClick(index);
     scrollToElement(sectionIds, index);
+
+    if (type === 'filter') {
+      logClickEvent('click_tag', {
+        label: TAPS.filter[index],
+      });
+    } else {
+      logClickEvent('click_tab', {
+        screen: 'top_tab',
+        label: TAPS.detail[index],
+      });
+    }
   };
 
   useEffect(() => {

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,8 +1,11 @@
 import Icon from '@assets/svgs';
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 import * as styles from './footer.css';
 
 const Footer = () => {
+  const { logClickEvent } = useEventLogger('my');
+
   return (
     <footer className={styles.footerContainer}>
       <div className={styles.topBox}>
@@ -31,14 +34,16 @@ const Footer = () => {
         <a
           href="https://www.notion.so/17c7c7beb77880d99c12d8c2375d562d?pvs=4"
           target="_blank"
-          rel="noreferrer">
+          rel="noreferrer"
+          onClick={() => logClickEvent('click_privacy_policy')}>
           개인정보처리방침
         </a>
         <Icon.IcnDivider />
         <a
           href="https://www.notion.so/17c7c7beb7788007b1d3eb99e0c33e47?pvs=4"
           target="_blank"
-          rel="noreferrer">
+          rel="noreferrer"
+          onClick={() => logClickEvent('click_terms_of_service')}>
           이용약관
         </a>
       </nav>

--- a/src/components/search/searchBar/SearchBar.tsx
+++ b/src/components/search/searchBar/SearchBar.tsx
@@ -2,6 +2,7 @@ import Icon from '@assets/svgs';
 import useFilter from '@hooks/useFilter';
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 import * as styles from './searchBar.css';
 
@@ -14,6 +15,7 @@ const SearchBar = ({ searchText }: SearchBarProps) => {
 
   const { handleSearch, handleResetFilter } = useFilter();
   const location = useLocation();
+  const { logClickEvent } = useEventLogger('search_bar');
 
   const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
@@ -24,12 +26,15 @@ const SearchBar = ({ searchText }: SearchBarProps) => {
 
   const handleClearInput = () => {
     setInputValue('');
+
+    logClickEvent('click_delete', { label: inputValue });
   };
 
   const handleClickSearch = () => {
     if (inputValue.trim() === '') return;
 
     handleSearch(inputValue);
+    logClickEvent('click_enter', { label: inputValue });
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/templeDetail/naverMap/smallMap/SmallMap.tsx
+++ b/src/components/templeDetail/naverMap/smallMap/SmallMap.tsx
@@ -2,6 +2,7 @@ import TextBtn from '@components/common/button/textBtn/TextBtn';
 import DetailTitle from '@components/detailTitle/DetailTitle';
 import useNavigateTo from '@hooks/useNavigateTo';
 import { useParams } from 'react-router-dom';
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 import * as styles from './smallMap.css';
 import MapContainer from '../MapContainer';
@@ -16,6 +17,8 @@ const SmallMap = ({ detailAddress, latitude, longitude }: MapDataProps) => {
   const copyToClipboard = () => {
     navigator.clipboard.writeText(detailAddress);
     alert('주소가 복사되었습니다.');
+
+    logClickEvent('click_copy', { label: detailAddress });
   };
 
   const { templestayId } = useParams();
@@ -23,6 +26,7 @@ const SmallMap = ({ detailAddress, latitude, longitude }: MapDataProps) => {
   const navigateToHome = useNavigateTo(
     `/detail/${templestayId}/map?latitude=${latitude}&longitude=${longitude}`,
   );
+  const { logClickEvent } = useEventLogger('map');
 
   return (
     <div className={styles.mapContainerWrapper} id="detail-section-4">

--- a/src/components/templeDetail/templeReview/TempleReview.tsx
+++ b/src/components/templeDetail/templeReview/TempleReview.tsx
@@ -4,6 +4,7 @@ import DetailTitle from '@components/detailTitle/DetailTitle';
 import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
 import useNavigateTo from '@hooks/useNavigateTo';
 import { useParams } from 'react-router-dom';
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 import * as styles from './templeReview.css';
 
@@ -12,6 +13,13 @@ const TempleReview = () => {
   const navigateToLargeReview = useNavigateTo(`/detail/${templestayId}/blog`);
 
   const { data, isLoading, isError } = useGetTempleReviews(String(templestayId), Number(1));
+
+  const { logClickEvent } = useEventLogger('blog_review');
+
+  const handleClickAllReview = () => {
+    navigateToLargeReview();
+    logClickEvent('click_all');
+  };
 
   if (isLoading) {
     return <ExceptLayout type="loading" />;
@@ -36,7 +44,7 @@ const TempleReview = () => {
         title="리뷰"
         isTotal={true}
         rigntBtnLabel="전체보기"
-        onClick={navigateToLargeReview}
+        onClick={handleClickAllReview}
       />
       <div className={styles.templeReviewContainer}>
         {data.reviews.slice(0, 5).map((review) => (

--- a/src/components/userInfo/userInfo.tsx
+++ b/src/components/userInfo/userInfo.tsx
@@ -1,3 +1,5 @@
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
+
 import infoContainerStyle from './userInfo.css';
 import AccountActions from './userInfoContent/accountAction/AccountAction';
 import HelpSection from './userInfoContent/helpContent/HelpContent';
@@ -18,12 +20,15 @@ interface UserInfoProps {
 }
 
 const UserInfo = ({ data, onLogoutClick, onDeleteClick }: UserInfoProps) => {
+  const { logClickEvent } = useEventLogger('my');
   const handleNoticeClick = () => {
     window.open('https://www.notion.so/1817c7beb7788076bdddfd4ba4b43008?pvs=4', '_blank');
+    logClickEvent('click_announce');
   };
 
   const handleQuestionClick = () => {
     window.open('https://www.notion.so/1807c7beb7788005a73bc799ce8719bf?pvs=4', '_blank');
+    logClickEvent('click_contact');
   };
 
   if (!data) {

--- a/src/constants/regionInfos.ts
+++ b/src/constants/regionInfos.ts
@@ -1,4 +1,4 @@
-const REGION_INFOS = {
+export const REGION_INFOS = {
   서울: { top: 40, left: 90 },
   인천: { top: 50, left: 20 },
   경기: { top: 88, left: 98 },
@@ -15,4 +15,19 @@ const REGION_INFOS = {
   제주: { top: 357, left: 10 },
 };
 
-export default REGION_INFOS;
+export const REGION_LABEL_MAP: Record<string, string> = {
+  서울: 'seoul',
+  인천: 'incheon',
+  경기: 'gyeonggi',
+  강원: 'gangwon',
+  충남: 'chungnam',
+  충북: 'chungbuk',
+  전북: 'jeonbuk',
+  광주: 'gwangju',
+  전남: 'jeonnam',
+  경북: 'gyeongbuk',
+  대구: 'daegu',
+  부산: 'busan',
+  경남: 'gyeongnam',
+  제주: 'jeju',
+};

--- a/src/gtm/GTMProvider.tsx
+++ b/src/gtm/GTMProvider.tsx
@@ -1,0 +1,31 @@
+import { useEffect, ReactNode } from 'react';
+
+import { DataLayerEvent } from './types';
+
+const GTM_ID = 'GTM-PW9GZMJG';
+
+interface GTMProviderProps {
+  children: ReactNode;
+}
+
+const GTMProvider = ({ children }: GTMProviderProps) => {
+  useEffect(() => {
+    if (!window.dataLayer) {
+      window.dataLayer = [];
+    }
+
+    window.dataLayer.push({
+      event: 'gtm.js',
+      'gtm.start': new Date().getTime(),
+    } as DataLayerEvent);
+
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = `https://www.googletagmanager.com/gtm.js?id=${GTM_ID}`;
+    document.head.appendChild(script);
+  }, []);
+
+  return <>{children}</>;
+};
+
+export default GTMProvider;

--- a/src/gtm/hooks/useEventLogger.ts
+++ b/src/gtm/hooks/useEventLogger.ts
@@ -1,0 +1,26 @@
+import { ClickEvent } from '../types';
+
+const useEventLogger = (screen: string) => {
+  const logClickEvent = (
+    event: ClickEvent['event'],
+    additionalFields?: Omit<ClickEvent, 'event' | 'screen'>,
+  ) => {
+    if (!window.dataLayer) return;
+
+    const eventObj: ClickEvent = {
+      event,
+      screen,
+      ...additionalFields,
+    };
+
+    if (process.env.NODE_ENV === 'development') {
+      console.log('[GTM] logClickEvent:', eventObj);
+    }
+
+    window.dataLayer.push(eventObj);
+  };
+
+  return { logClickEvent };
+};
+
+export default useEventLogger;

--- a/src/gtm/hooks/useEventLogger.ts
+++ b/src/gtm/hooks/useEventLogger.ts
@@ -1,15 +1,18 @@
 import { ClickEvent } from '../types';
 
 const useEventLogger = (screen: string) => {
+  const defaultUrl = typeof window !== 'undefined' ? window.location.pathname : '';
+
   const logClickEvent = (
     event: ClickEvent['event'],
-    additionalFields?: Omit<ClickEvent, 'event' | 'screen'>,
+    additionalFields?: Omit<ClickEvent, 'event' | 'screen_name'>,
   ) => {
     if (!window.dataLayer) return;
 
     const eventObj: ClickEvent = {
       event,
       screen,
+      url: defaultUrl,
       ...additionalFields,
     };
 

--- a/src/gtm/types.ts
+++ b/src/gtm/types.ts
@@ -1,0 +1,24 @@
+export interface BaseDataLayerEvent {
+  event: string;
+}
+
+export interface ClickEvent extends BaseDataLayerEvent {
+  event: string;
+  screen: string;
+  label?: string;
+  [key: string]: unknown;
+}
+
+export interface PageViewEvent extends BaseDataLayerEvent {
+  event: 'page_view';
+  pagePath: string;
+  [key: string]: unknown;
+}
+
+export interface GtmStartEvent extends BaseDataLayerEvent {
+  event: 'gtm.js';
+  'gtm.start': number;
+  [key: string]: unknown;
+}
+
+export type DataLayerEvent = ClickEvent | PageViewEvent | GtmStartEvent;

--- a/src/gtm/types.ts
+++ b/src/gtm/types.ts
@@ -6,6 +6,7 @@ export interface ClickEvent extends BaseDataLayerEvent {
   event: string;
   screen: string;
   label?: string;
+  url?: string;
   [key: string]: unknown;
 }
 

--- a/src/gtm/window.d.ts
+++ b/src/gtm/window.d.ts
@@ -1,0 +1,7 @@
+import { DataLayerEvent } from 'src/gtm/types';
+
+declare global {
+  interface Window {
+    dataLayer: DataLayerEvent[];
+  }
+}

--- a/src/hooks/useExpandHook/useExpandHook.tsx
+++ b/src/hooks/useExpandHook/useExpandHook.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, RefObject } from 'react';
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 const useExpandHook = (contentRef: RefObject<HTMLElement>) => {
   const [isAppeared, setIsAppeared] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
+  const { logClickEvent } = useEventLogger('info');
 
   useEffect(() => {
     const contentElement = contentRef.current;
@@ -13,6 +15,7 @@ const useExpandHook = (contentRef: RefObject<HTMLElement>) => {
 
   const handleToggleExpand = () => {
     setIsExpanded((prev) => !prev);
+    logClickEvent(`click_${isExpanded ? 'fold' : 'more'}`);
   };
 
   return {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Provider } from 'jotai';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import GTMProvider from 'src/gtm/GTMProvider.tsx';
 import Router from 'src/router/Router.tsx';
 
 import '@styles/reset.css.ts';
@@ -18,9 +19,11 @@ createRoot(document.getElementById('root')!).render(
       <div style={{ fontSize: '16px' }}>
         <ReactQueryDevtools initialIsOpen={false} />
       </div>
-      <Provider>
-        <Router />
-      </Provider>
+      <GTMProvider>
+        <Provider>
+          <Router />
+        </Provider>
+      </GTMProvider>
     </QueryClientProvider>
   </StrictMode>,
 );

--- a/src/pages/filterPage/FilterPage.tsx
+++ b/src/pages/filterPage/FilterPage.tsx
@@ -7,6 +7,7 @@ import FILTERS from '@constants/filters';
 import useFilter from '@hooks/useFilter';
 import { useAtomValue } from 'jotai';
 import { useLocation } from 'react-router-dom';
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
 import { filterListAtom } from 'src/store/store';
 import titleMap from 'src/type/titleMap';
 
@@ -20,6 +21,14 @@ const FilterPage = () => {
   const filterInstance = useAtomValue(filterListAtom);
 
   const filtersState = filterInstance.getAllStates();
+  const { logClickEvent } = useEventLogger('filter_tag');
+
+  const searchFilter = async () => {
+    await handleSearch();
+    logClickEvent('click_list', {
+      label: '',
+    });
+  };
 
   return (
     <div>
@@ -45,7 +54,7 @@ const FilterPage = () => {
         type="reset"
         label={`${totalCount || 0}개의 템플스테이 보기`}
         largeBtnClick={() => {
-          handleSearch();
+          searchFilter();
         }}
         handleResetFilter={handleResetFilter}
       />

--- a/src/pages/homePage/HomePage.tsx
+++ b/src/pages/homePage/HomePage.tsx
@@ -12,6 +12,7 @@ import useFilter from '@hooks/useFilter';
 import useNavigateTo from '@hooks/useNavigateTo';
 import { useSetAtom } from 'jotai';
 import { useEffect, useState } from 'react';
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
 import { contentAtom } from 'src/store/store';
 
 import * as styles from './homePage.css';
@@ -22,12 +23,21 @@ const HomePage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const navigateToLogin = useNavigateTo('/loginStart');
+  const { logClickEvent } = useEventLogger('modal_login_wish');
+
+  const handleLogin = () => {
+    navigateToLogin();
+    logClickEvent('click_login');
+  };
+
   const openModal = () => {
     setIsModalOpen(true);
   };
 
   const closeModal = () => {
     setIsModalOpen(false);
+
+    logClickEvent('click_cancel');
   };
 
   useEffect(() => {
@@ -52,7 +62,7 @@ const HomePage = () => {
             modalBody="찜하려면 로그인이 필요해요."
             isOpen={isModalOpen}
             handleClose={closeModal}
-            handleSubmit={navigateToLogin}
+            handleSubmit={handleLogin}
             leftBtnLabel="취소"
             rightBtnLabel="로그인하기"
           />

--- a/src/pages/myPage/MyPage.tsx
+++ b/src/pages/myPage/MyPage.tsx
@@ -6,6 +6,7 @@ import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
 import Footer from '@components/footer/Footer';
 import UserInfo from '@components/userInfo/userInfo';
 import { useState } from 'react';
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 import * as styles from './myPage.css';
 
@@ -21,22 +22,44 @@ const MyPage = () => {
 
   const { data, isLoading, isError } = useGetMyPage(userId);
 
+  const { logClickEvent } = useEventLogger('my');
+
   const handleLogoutClick = () => {
     setIsLogoutModalOpen(true);
+
+    logClickEvent('click_logout');
   };
 
   const confirmLogout = () => {
     postLogout.mutate();
     setIsLogoutModalOpen(false);
+
+    logClickEvent('click_logout', { screen: 'logout_modal' });
   };
 
   const handleDeleteClick = () => {
     setIsDeleteModalOpen(true);
+
+    logClickEvent('click_unsubscribe');
   };
 
   const confirmDelete = () => {
     postWithdraw.mutate();
     setIsLogoutModalOpen(false);
+
+    logClickEvent('click_unsubscribe', { screen: 'unsubscribe_modal' });
+  };
+
+  const handleCloseLogoutModal = () => {
+    setIsLogoutModalOpen(false);
+
+    logClickEvent('click_cancel', { screen: 'logout_modal' });
+  };
+
+  const handleCloseDeleteModal = () => {
+    setIsDeleteModalOpen(false);
+
+    logClickEvent('click_cancel', { screen: 'unsubscribe_modal' });
   };
 
   if (isLoading) {
@@ -61,7 +84,7 @@ const MyPage = () => {
             modalTitle="정말 로그아웃하시겠어요?"
             modalBody="로그아웃 시 일부 기능 이용이 제한됩니다"
             isOpen={isLogoutModalOpen}
-            handleClose={() => setIsLogoutModalOpen(false)}
+            handleClose={handleCloseLogoutModal}
             handleSubmit={confirmLogout}
             leftBtnLabel="취소"
             rightBtnLabel="로그아웃하기"
@@ -76,7 +99,7 @@ const MyPage = () => {
             modalTitle="정말 탈퇴하시겠어요?"
             modalBody="탈퇴 시 계정 정보는 복구할 수 없습니다"
             isOpen={isDeleteModalOpen}
-            handleClose={() => setIsDeleteModalOpen(false)}
+            handleClose={handleCloseDeleteModal}
             handleSubmit={confirmDelete}
             leftBtnLabel="취소"
             rightBtnLabel="탈퇴하기"

--- a/src/pages/onboardingPage/OnboardingPage.tsx
+++ b/src/pages/onboardingPage/OnboardingPage.tsx
@@ -6,6 +6,7 @@ import OnboardingSection from '@components/onboarding/OnboardingSection';
 import { ONBOARDING_STEPS, COMMON_DESCRIPTION } from '@constants/onboarding/onboardingSteps';
 import useFunnel from '@hooks/useFunnel';
 import React, { useState, useEffect } from 'react';
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 import container from './onboardingPage.css';
 
@@ -14,6 +15,8 @@ const OnboardingPage = () => {
     ONBOARDING_STEPS.map((step) => step.id),
     '/welcome',
   );
+
+  const { logClickEvent } = useEventLogger('onboarding');
 
   const [selections, setSelections] = useState<Record<string, string | null>>(() => {
     const savedSelections = localStorage.getItem('onboardingSelections');
@@ -101,7 +104,17 @@ const OnboardingPage = () => {
                 isNextDisabledInitially={isNextDisabledInitially || false}
                 selectedOption={selections[id]}
                 onSelectionChange={(selected) => handleSelectionChange(id, selected)}
-                onNextClick={isFinalStep ? handleFinalSubmit : nextStep}
+                onNextClick={() => {
+                  logClickEvent('click_next', {
+                    screen: `onboarding_${id}`,
+                  });
+
+                  if (isFinalStep) {
+                    handleFinalSubmit();
+                  } else {
+                    nextStep();
+                  }
+                }}
               />
             </Step>
           );

--- a/src/pages/searchResultPage/SearchResultPage.tsx
+++ b/src/pages/searchResultPage/SearchResultPage.tsx
@@ -11,6 +11,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useAtomValue } from 'jotai';
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
 import { filterListAtom } from 'src/store/store';
 
 import * as styles from './searchResultPage.css';
@@ -24,6 +25,8 @@ const SearchResultPage = () => {
 
   const addWishlistMutation = useAddWishlist();
   const removeWishlistMutation = useRemoveWishlist();
+
+  const { logClickEvent } = useEventLogger('modal_login_wish');
 
   useEffect(() => {
     if (results) {
@@ -40,7 +43,15 @@ const SearchResultPage = () => {
   const { handleSearch } = useFilter();
 
   const openModal = () => setIsModalOpen(true);
-  const closeModal = () => setIsModalOpen(false);
+  const closeModal = () => {
+    setIsModalOpen(false);
+    logClickEvent('click_cancel');
+  };
+
+  const handleLogin = () => {
+    navigateToLogin();
+    logClickEvent('click_login');
+  };
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
@@ -78,7 +89,7 @@ const SearchResultPage = () => {
           modalBody="찜하려면 로그인이 필요해요."
           isOpen={isModalOpen}
           handleClose={closeModal}
-          handleSubmit={navigateToLogin}
+          handleSubmit={handleLogin}
           leftBtnLabel="취소"
           rightBtnLabel="로그인하기"
         />

--- a/src/pages/templeDetailPage/TempleDetailPage.tsx
+++ b/src/pages/templeDetailPage/TempleDetailPage.tsx
@@ -18,6 +18,7 @@ import useNavigateTo from '@hooks/useNavigateTo';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 import * as styles from './templeDetailPage.css';
 
@@ -42,6 +43,8 @@ const TempleDetailPage = () => {
     }
   }, [data]);
 
+  const { logClickEvent } = useEventLogger('bottom_tab');
+
   const handleToggleWishlist = () => {
     if (!userId) {
       setIsModalOpen(true);
@@ -60,9 +63,20 @@ const TempleDetailPage = () => {
         },
       },
     );
+
+    logClickEvent(`click_wish_${liked ? 'remove' : 'add'}`, {});
   };
 
-  const closeModal = () => setIsModalOpen(false);
+  const closeModal = () => {
+    setIsModalOpen(false);
+
+    logClickEvent('click_cancel', { screen: 'modal_login_wish' });
+  };
+
+  const handleLogin = () => {
+    navigateToLogin();
+    logClickEvent('click_login', { screen: 'modal_login_wish' });
+  };
 
   if (isLoading) {
     return <ExceptLayout type="loading" />;
@@ -78,6 +92,8 @@ const TempleDetailPage = () => {
 
   const handleBottomButtonClick = () => {
     window.open(data.url, '_blank');
+
+    logClickEvent('click_reserve', { label: data.templeName });
   };
 
   return (
@@ -88,7 +104,7 @@ const TempleDetailPage = () => {
           modalBody="찜하려면 로그인이 필요해요."
           isOpen={isModalOpen}
           handleClose={closeModal}
-          handleSubmit={navigateToLogin}
+          handleSubmit={handleLogin}
           leftBtnLabel="취소"
           rightBtnLabel="로그인하기"
         />

--- a/src/pages/welcomePage/WelcomePage.tsx
+++ b/src/pages/welcomePage/WelcomePage.tsx
@@ -4,6 +4,7 @@ import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
 import { WELCOME_TEXT } from '@constants/onboarding/onboardingSteps';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 import * as styles from './welcomePage.css';
 
@@ -11,6 +12,7 @@ const WelcomePage = () => {
   const navigate = useNavigate();
   const userId = Number(localStorage.getItem('userId'));
   const { data, isLoading } = useGetNickname(userId);
+  const { logClickEvent } = useEventLogger('onboarding_end');
 
   if (isLoading) {
     return <ExceptLayout type="loading" />;
@@ -18,7 +20,10 @@ const WelcomePage = () => {
 
   const handleStart = () => {
     navigate('/');
+
+    logClickEvent('click_start');
   };
+
   return (
     <div className={styles.container}>
       <h1 className={styles.titleStyle}>{`${data?.nickname}${WELCOME_TEXT}`}</h1>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #267

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- GTM 스크립트를 삽입하는 GTMProvider 컴포넌트를 추가했어요.
- 클릭 이벤트를 dataLayer에 로깅하는 useEventLogger 커스텀 훅을 만들었어요.
- 기획에서 정의해준 이벤트 정의서를 기반으로 클릭 이벤트를 모두 심어두었어요! ga관련 자료는 [여기서](https://www.notion.so/GA-a3f4787f0e6d43cbab399ac47a69e9c7) 확인가능해요

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- GTMProvider는 마운트 시점에 gtm.js 이벤트를 dataLayer에 푸시하고, <script> 태그를 생성해 GTM 스크립트를 동적으로 로드해요.
- useEventLogger는 현재 화면 이름(screen)과 window.location.pathname을 바탕으로 클릭 이벤트 정보를 생성하고, 이를 dataLayer에 푸시해요. 개발환경에선 콘솔에도 로깅되도록 했어요.
- 모든 클릭 이벤트에 대해서 로깅이 되는 것을 확인했어요.

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- 기획에서 정의해준 클릭 이벤트를 넣고 싶을때에는 
```
const { logClickEvent } = useEventLogger(기획이 작성해준 스크린명);
logClickEvent(이벤트 이름)
```
으로 사용하시면 됩니다! 

예시 코드를 보면 
![image](https://github.com/user-attachments/assets/f2f673c0-67d4-4bd8-95cd-5272051b5dc0)
위와 같은 이벤트를 추가하고자 할때는 
``` jsx
  const { logClickEvent } = useEventLogger('blog_review');

  const handleClickAllReview = () => {
    navigateToLargeReview();
    logClickEvent('click_all');
  };

```
이와 같이 추가하시면 됩니다!!

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->
![image](https://github.com/user-attachments/assets/04db9d26-78fc-4479-83fa-701b72611d75)
이와 같은 형식으로 데이터를 로깅합니다