### PR TITLE
[FEAT] react-router-dom을 통해서 라우팅하는 방식 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint src/**/*.{ts,tsx} --fix",
-    "next": "next build",
+    "next": "next dev",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",

--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -1,9 +1,9 @@
 import { postKakaoLogin, postLogout, postWithdraw } from '@apis/auth/axios';
 import { useMutation } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { useRouter } from 'next/navigation';
 
 export const usePostKakaoLogin = () => {
-  const navigate = useNavigate();
+  const router = useRouter();
 
   return useMutation({
     mutationFn: ({ code, redirectUri }: { code: string; redirectUri: string }) =>
@@ -20,9 +20,9 @@ export const usePostKakaoLogin = () => {
       localStorage.removeItem('searchKeyword');
 
       if (!userNickname) {
-        navigate('/onboarding');
+        router.push('/onboarding');
       } else {
-        navigate('/');
+        router.push('/');
       }
     },
     onError: (error) => {
@@ -32,13 +32,13 @@ export const usePostKakaoLogin = () => {
 };
 
 export const usePostLogout = () => {
-  const navigate = useNavigate();
+  const router = useRouter();
 
   return useMutation({
     mutationFn: () => postLogout(),
     onSuccess: () => {
       localStorage.clear();
-      navigate('/');
+      router.push('/');
     },
 
     onError: (error) => {
@@ -48,7 +48,7 @@ export const usePostLogout = () => {
 };
 
 export const usePostWithdraw = ({ userId }: { userId: number | null }) => {
-  const navigate = useNavigate();
+  const router = useRouter();
 
   return useMutation({
     mutationFn: async () => {
@@ -57,7 +57,7 @@ export const usePostWithdraw = ({ userId }: { userId: number | null }) => {
     },
     onSuccess: () => {
       localStorage.clear();
-      navigate('/');
+      router.push('/');
       window.location.reload();
     },
     onError: (error) => {

--- a/src/app/curation/page.tsx
+++ b/src/app/curation/page.tsx
@@ -2,13 +2,18 @@
 
 import PageName from '@components/common/pageName/PageName';
 import { CURATION_IMAGES } from '@constants/curationInfo';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'next/navigation';
 
 import { headerBox, contentBox } from './curationPage.css';
 
+export const dynamic = 'force-dynamic';
+
 const CurationPage = () => {
-  const { index } = useParams();
-  const indexNum = parseInt(index || '0');
+  const params = useParams();
+  const indexRaw = params?.index;
+
+  const indexStr = Array.isArray(indexRaw) ? indexRaw[0] : indexRaw || '0';
+  const indexNum = parseInt(indexStr);
 
   const images = Object.values(CURATION_IMAGES)[indexNum - 1] || [];
 

--- a/src/app/detail/[templestayId]/blog/page.tsx
+++ b/src/app/detail/[templestayId]/blog/page.tsx
@@ -4,8 +4,8 @@ import ReviewCard from '@components/card/reviewCard/reviewCard/ReviewCard';
 import PageName from '@components/common/pageName/PageName';
 import Pagination from '@components/common/pagination/Pagination';
 import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
+import { useParams } from 'next/navigation';
 import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
 
 import * as styles from './style.css';
 

--- a/src/app/detail/[templestayId]/map/page.tsx
+++ b/src/app/detail/[templestayId]/map/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 import smallMarker from '@assets/images/icn_map.png';
 import ArrowBtn from '@components/common/button/arrowBtn/ArrowBtn';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
 
 import * as styles from './style.css';
 
@@ -50,17 +50,16 @@ const MapContainer = ({ latitude, longitude, size }: MapContainerProps) => {
 };
 
 const LargeMap = () => {
-  const navigate = useNavigate();
-  const location = useLocation();
-  const params = new URLSearchParams(location.search);
-  const latitudeString = params.get('latitude');
-  const longitudeString = params.get('longitude');
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const latitudeString = searchParams.get('latitude');
+  const longitudeString = searchParams.get('longitude');
 
   const latitude = latitudeString ? parseFloat(latitudeString) : 0;
   const longitude = longitudeString ? parseFloat(longitudeString) : 0;
 
   const handleToBack = () => {
-    navigate(-1);
+    router.back();
     window.addEventListener('popstate', () => {
       setTimeout(() => {
         window.scrollTo(0, document.body.scrollHeight);

--- a/src/app/detail/[templestayId]/page.tsx
+++ b/src/app/detail/[templestayId]/page.tsx
@@ -17,8 +17,8 @@ import TempleTitle from '@components/templeDetail/templeTitle/TempleTitle';
 import TempleTopbar from '@components/templeDetail/templeTopbar/TempleTopbar';
 import useNavigateTo from '@hooks/useNavigateTo';
 import { useQueryClient } from '@tanstack/react-query';
+import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
 import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 import * as styles from './detail.css';

--- a/src/app/detail/[templestayId]/photo/page.tsx
+++ b/src/app/detail/[templestayId]/photo/page.tsx
@@ -3,7 +3,7 @@
 import useGetTempleImages from '@apis/templeImages';
 import PageName from '@components/common/pageName/PageName';
 import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'next/navigation';
 
 import * as styles from './style.css';
 

--- a/src/app/filter/page.tsx
+++ b/src/app/filter/page.tsx
@@ -8,18 +8,20 @@ import FilterBox from '@components/filter/filterBox/FilterBox';
 import FILTERS from '@constants/filters';
 import useFilter from '@hooks/useFilter';
 import { useAtomValue } from 'jotai';
-import { useLocation } from 'react-router-dom';
+import { useSearchParams } from 'next/navigation';
 import useEventLogger from 'src/gtm/hooks/useEventLogger';
 import { filterListAtom } from 'src/store/store';
 import titleMap from 'src/type/titleMap';
 
 import * as styles from './filterPage.css';
 
+export const dynamic = 'force-dynamic';
+
 const FilterPage = () => {
   const { totalCount, toggleFilter, handleResetFilter, handleSearch } = useFilter();
 
-  const location = useLocation();
-  const { selectedTap } = location.state || {};
+  const searchParams = useSearchParams();
+  const selectedTap = searchParams.get('selectedTap') ?? undefined;
   const filterInstance = useAtomValue(filterListAtom);
 
   const filtersState = filterInstance.getAllStates();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from 'react';
 import ClientProviders from './layout.client';
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://www.gototemplestay.com'),
   title: '절로가 | 템플스테이를 만나는 가장 쉬운 방법',
   description: '템플스테이를 쉽고 빠르게 찾고, 지친 일상에 특별한 휴식을 더해보세요.',
   keywords: [
@@ -37,6 +38,8 @@ export const metadata: Metadata = {
     canonical: 'https://www.gototemplestay.com/',
   },
 };
+
+export const dynamic = 'force-dynamic';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,19 +1,22 @@
 'use client';
 
 import KakaoBtn from '@components/common/button/kakaoBtn/KakaoBtn';
+import LottiePlayer from '@components/common/lottie/LottiePlayer';
 import PageName from '@components/common/pageName/PageName';
 import LOGIN_INFOS from '@constants/loginInfos';
-import { useLocation } from 'react-router-dom';
+import { useSearchParams } from 'next/navigation';
 
 import * as styles from './loginPage.css';
 
 type LoginType = 'my' | 'wish';
 
 const LoginPage = () => {
-  const location = useLocation();
+  const searchParams = useSearchParams();
+  const typeParam = searchParams.get('type');
+  const isPrivateParam = searchParams.get('isPrivate');
 
-  const type: LoginType = location.state?.type || 'wish';
-  const isPrivate = location.state?.isPrivate || false;
+  const type: LoginType = typeParam === 'my' ? 'my' : 'wish';
+  const isPrivate = isPrivateParam === 'true';
 
   const { title, text, lottie } = LOGIN_INFOS[type];
 
@@ -23,13 +26,7 @@ const LoginPage = () => {
       <div className={styles.contentWrapper}>
         <h2 className={styles.textStyle}>{text}</h2>
 
-        <dotlottie-player
-          key={type}
-          src={lottie}
-          autoplay
-          loop
-          style={{ width: '27rem', height: '28.8rem' }}
-        />
+        <LottiePlayer keyId={type} src={lottie} style={{ width: '27rem', height: '28.8rem' }} />
       </div>
       <KakaoBtn />
     </section>

--- a/src/app/loginStart/page.tsx
+++ b/src/app/loginStart/page.tsx
@@ -1,5 +1,8 @@
+'use client';
+
 import Icon from '@assets/svgs';
 import KakaoBtn from '@components/common/button/kakaoBtn/KakaoBtn';
+import LottiePlayer from '@components/common/lottie/LottiePlayer';
 import React from 'react';
 
 import * as styles from './style.css';
@@ -12,7 +15,7 @@ const ModalLoginPage = () => {
         <p className={styles.textStyle}>템플스테이를 만나는 가장 쉬운 방법</p>
       </div>
       <div className={styles.lottieStyle}>
-        <dotlottie-player key="onboarding" src="/lotties/onboarding.lottie" autoplay loop />
+        <LottiePlayer keyId="onboarding" src="/lotties/onboarding.lottie" />
       </div>
       <KakaoBtn />
     </div>

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -2,16 +2,17 @@
 
 import { useGetNickname } from '@apis/user';
 import PageBottomBtn from '@components/common/button/pageBottomBtn/PageBottomBtn';
+import LottiePlayer from '@components/common/lottie/LottiePlayer';
 import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
 import { WELCOME_TEXT } from '@constants/onboarding/onboardingSteps';
+import { useRouter } from 'next/navigation';
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
 import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 import * as styles from './welcomePage.css';
 
 const WelcomePage = () => {
-  const navigate = useNavigate();
+  const router = useRouter();
   const userId = Number(localStorage.getItem('userId'));
   const { data, isLoading } = useGetNickname(userId);
   const { logClickEvent } = useEventLogger('onboarding_end');
@@ -21,7 +22,7 @@ const WelcomePage = () => {
   }
 
   const handleStart = () => {
-    navigate('/');
+    router.push('/');
 
     logClickEvent('click_start');
   };
@@ -30,7 +31,7 @@ const WelcomePage = () => {
     <div className={styles.container}>
       <h1 className={styles.titleStyle}>{`${data?.nickname}${WELCOME_TEXT}`}</h1>
       <div className={styles.lottieStyle}>
-        <dotlottie-player key="onboarding" src="/lotties/onboarding.lottie" autoplay loop />
+        <LottiePlayer keyId="onboarding" src="/lotties/onboarding.lottie" />
       </div>
       <PageBottomBtn btnText="절로가 시작하기" size="large" onClick={handleStart} />
     </div>

--- a/src/components/card/templeStayCard/TempleStayCard.tsx
+++ b/src/components/card/templeStayCard/TempleStayCard.tsx
@@ -2,8 +2,8 @@
 const errorImage = '/assets/images/img_gray_light_leaf_medium.png';
 import InfoSection from '@components/card/templeStayCard/InfoSection';
 import FlowerIcon from '@components/common/icon/flowerIcon/FlowerIcon';
+import { usePathname } from 'next/navigation';
 import { useState } from 'react';
-import { useLocation } from 'react-router-dom';
 import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 import * as styles from './templeStayCard.css';
@@ -40,10 +40,9 @@ const TempleStayCard = ({
   const [isWished, setIsWished] = useState(liked);
   const isHorizontal = layout === 'horizontal';
   const { logClickEvent } = useEventLogger('templestay_card');
-  const location = useLocation();
+  const pathname = usePathname();
 
-  const isWishPage = location.pathname === '/wishList';
-  console.log(location.pathname);
+  const isWishPage = pathname === '/wishList';
 
   const onClickWishBtn = (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/src/components/carousel/detailCarousel/DetailCarousel.tsx
+++ b/src/components/carousel/detailCarousel/DetailCarousel.tsx
@@ -3,7 +3,7 @@ const largeEmptyImage = '@assets/images/img_gray_light_leaf_large.png';
 import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
 import useCarousel from '@hooks/useCarousel';
 import registDragEvent from '@utils/registDragEvent';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'next/navigation';
 
 import * as styles from './detailCarousel.css';
 import ImageItem from './DetailImage';

--- a/src/components/carousel/detailCarousel/DetailImage.tsx
+++ b/src/components/carousel/detailCarousel/DetailImage.tsx
@@ -1,5 +1,5 @@
 import useNavigateTo from '@hooks/useNavigateTo';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'next/navigation';
 
 import * as styles from './detailCarousel.css';
 import NumberTag from './numberTag/NumberTag';

--- a/src/components/common/empty/filterEmpty/FilterEmpty.tsx
+++ b/src/components/common/empty/filterEmpty/FilterEmpty.tsx
@@ -1,3 +1,5 @@
+'use client';
+import LottiePlayer from '@components/common/lottie/LottiePlayer';
 import React from 'react';
 
 import * as styles from './filterEmpty.css';
@@ -7,11 +9,9 @@ const FilterEmpty = () => {
     <div className={styles.container}>
       <div>
         <p className={styles.textStyle}>{'해당되는 템플스테이를\n찾지 못했어요'}</p>
-        <dotlottie-player
-          key="filter"
+        <LottiePlayer
+          keyId="filter"
           src="/lotties/moktak_sad.lottie"
-          autoplay
-          loop
           style={{ width: '15rem', height: '10.3rem' }}
         />
       </div>

--- a/src/components/common/empty/searchEmpty/SearchEmpty.tsx
+++ b/src/components/common/empty/searchEmpty/SearchEmpty.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import LottiePlayer from '@components/common/lottie/LottiePlayer';
 import React from 'react';
 
 import * as styles from './searchEmpty.css';
@@ -13,11 +16,9 @@ const SearchEmpty = ({ text }: SearchEmptyProps) => {
         <p className={styles.textStyle}>
           '<span className={styles.highlight}>{`${text}`}</span>'{'에 대한\n검색결과가 없어요'}
         </p>
-        <dotlottie-player
-          key="search"
+        <LottiePlayer
+          keyId="search"
           src="/lotties/moktak_sad.lottie"
-          autoplay
-          loop
           style={{ width: '15rem', height: '10.3rem' }}
         />
       </div>

--- a/src/components/common/lottie/LottiePlayer.tsx
+++ b/src/components/common/lottie/LottiePlayer.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import React, { useEffect } from 'react';
+
+interface Props {
+  src: string;
+  keyId: string;
+  style?: React.CSSProperties;
+}
+
+const LottiePlayer = ({ src, keyId, style }: Props) => {
+  useEffect(() => {
+    import('@dotlottie/player-component');
+  }, []);
+
+  return <dotlottie-player key={keyId} src={src} autoplay loop style={style} />;
+};
+
+export default LottiePlayer;

--- a/src/components/common/pageName/PageName.tsx
+++ b/src/components/common/pageName/PageName.tsx
@@ -1,5 +1,7 @@
+'use client';
+
 import Icon from '@assets/svgs';
-import { useNavigate } from 'react-router-dom';
+import { useRouter } from 'next/navigation';
 
 import * as PageNameStyle from './pageName.css';
 
@@ -9,13 +11,13 @@ interface PageNameProps {
 }
 
 const PageName = ({ title, isPrivate }: PageNameProps) => {
-  const navigate = useNavigate();
+  const router = useRouter();
 
   const handleToBack = () => {
     if (isPrivate) {
-      navigate('/');
+      router.push('/');
     } else {
-      navigate(-1);
+      router.back();
     }
   };
 

--- a/src/components/except/exceptLayout/ExceptLayout.tsx
+++ b/src/components/except/exceptLayout/ExceptLayout.tsx
@@ -1,10 +1,10 @@
 'use client';
 
+import LottiePlayer from '@components/common/lottie/LottiePlayer';
 import EXCEPT_INFOS from '@constants/exceptInfos';
 import React from 'react';
 
 import * as styles from './exceptLayout.css';
-import '@dotlottie/player-component';
 
 interface ExceptLayoutProps {
   type: 'loading' | 'networkError';
@@ -17,13 +17,7 @@ const ExceptLayout = ({ type }: ExceptLayoutProps) => {
     <section className={styles.exceptWrapper}>
       <span className={styles.title}>{title}</span>
       <div className={styles.imgContainer}>
-        <dotlottie-player
-          key={type}
-          src={lottie}
-          autoplay
-          loop
-          style={{ width: 210, height: 210 }}
-        />
+        <LottiePlayer keyId={type} src={lottie} style={{ width: 210, height: 210 }} />
       </div>
       <span className={styles.subtitle[type]}>{subtitle}</span>
     </section>

--- a/src/components/filter/filterTypeBox/FilterTypeBox.tsx
+++ b/src/components/filter/filterTypeBox/FilterTypeBox.tsx
@@ -1,6 +1,6 @@
 import Icon from '@assets/svgs';
 import BasicBtn from '@components/common/button/basicBtn/BasicBtn';
-import { useNavigate } from 'react-router-dom';
+import { useRouter } from 'next/navigation';
 import titleMap from 'src/type/titleMap';
 
 import * as styles from './filterTypeBox.css';
@@ -10,10 +10,10 @@ interface FilterTypeBoxProps {
 }
 
 const FilterTypeBox = ({ activeFilters }: FilterTypeBoxProps) => {
-  const navigator = useNavigate();
+  const router = useRouter();
 
   const handleClickFilter = (filter: string) => {
-    navigator('/filter', { state: { selectedTap: filter } });
+    router.push(`/filter?selectedTap=${filter}`);
   };
 
   return (

--- a/src/components/search/searchBar/SearchBar.tsx
+++ b/src/components/search/searchBar/SearchBar.tsx
@@ -1,8 +1,8 @@
 'use client';
 import Icon from '@assets/svgs';
 import useFilter from '@hooks/useFilter';
+import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
 import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 import * as styles from './searchBar.css';
@@ -15,7 +15,6 @@ const SearchBar = ({ searchText }: SearchBarProps) => {
   const [inputValue, setInputValue] = useState(searchText || '');
 
   const { handleSearch, handleResetFilter } = useFilter();
-  const location = useLocation();
   const { logClickEvent } = useEventLogger('search_bar');
 
   const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -45,9 +44,11 @@ const SearchBar = ({ searchText }: SearchBarProps) => {
     }
   };
 
+  const pathname = usePathname();
+
   // 검색 페이지에서 입력하면 기존 필터 지우기
   useEffect(() => {
-    if (location.pathname === '/search') {
+    if (pathname === '/search') {
       handleResetFilter();
       localStorage.setItem('prevPage', '/search');
     }

--- a/src/components/templeDetail/naverMap/largeMap/LargeMap.tsx
+++ b/src/components/templeDetail/naverMap/largeMap/LargeMap.tsx
@@ -1,21 +1,22 @@
 import ArrowBtn from '@components/common/button/arrowBtn/ArrowBtn';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/router';
 
 import * as styles from './largeMap.css';
 import MapContainer from '../MapContainer';
 
 const LargeMap = () => {
-  const navigate = useNavigate();
-  const location = useLocation();
-  const params = new URLSearchParams(location.search);
-  const latitudeString = params.get('latitude');
-  const longitudeString = params.get('longitude');
+  const router = useRouter();
+
+  const searchParams = useSearchParams();
+  const latitudeString = searchParams.get('latitude');
+  const longitudeString = searchParams.get('longitude');
 
   const latitude = latitudeString ? parseFloat(latitudeString) : 0;
   const longitude = longitudeString ? parseFloat(longitudeString) : 0;
 
   const handleToBack = () => {
-    navigate(-1);
+    router.back();
     window.addEventListener('popstate', () => {
       setTimeout(() => {
         window.scrollTo(0, document.body.scrollHeight);

--- a/src/components/templeDetail/naverMap/smallMap/SmallMap.tsx
+++ b/src/components/templeDetail/naverMap/smallMap/SmallMap.tsx
@@ -1,7 +1,7 @@
 import TextBtn from '@components/common/button/textBtn/TextBtn';
 import DetailTitle from '@components/detailTitle/DetailTitle';
 import useNavigateTo from '@hooks/useNavigateTo';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'next/navigation';
 import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 import * as styles from './smallMap.css';

--- a/src/components/templeDetail/templeReview/TempleReview.tsx
+++ b/src/components/templeDetail/templeReview/TempleReview.tsx
@@ -3,7 +3,7 @@ import ReviewCard from '@components/card/reviewCard/reviewCard/ReviewCard';
 import DetailTitle from '@components/detailTitle/DetailTitle';
 import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
 import useNavigateTo from '@hooks/useNavigateTo';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'next/navigation';
 import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 import * as styles from './templeReview.css';

--- a/src/hooks/useFunnel.tsx
+++ b/src/hooks/useFunnel.tsx
@@ -1,5 +1,5 @@
+import { useRouter, useSearchParams } from 'next/navigation';
 import React, { ReactElement, ReactNode, useEffect } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
 
 interface StepProps {
   name: string;
@@ -19,8 +19,8 @@ type SetStepOptions = {
 };
 
 const useFunnel = (steps: string[], completePath: string) => {
-  const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
+  const router = useRouter();
+  const searchParams = useSearchParams();
 
   const currentStep = searchParams.get('step') || steps[0];
 
@@ -37,15 +37,13 @@ const useFunnel = (steps: string[], completePath: string) => {
       step: newStep,
     };
 
-    const updatedPath = {
-      pathname: '/onboarding',
-      search: `?${new URLSearchParams(updatedQuery)}`,
-    };
+    const searchString = new URLSearchParams(updatedQuery).toString();
+    const targetUrl = `/onboarding?${searchString}`;
 
     if (stepChangeType === 'replace') {
-      navigate(updatedPath, { replace: true });
+      router.replace(targetUrl);
     } else {
-      navigate(updatedPath);
+      router.push(targetUrl);
     }
   };
 
@@ -55,7 +53,7 @@ const useFunnel = (steps: string[], completePath: string) => {
     if (nextIndex < steps.length) {
       setStep(steps[nextIndex]);
     } else {
-      navigate(completePath);
+      router.push(completePath);
     }
   };
 
@@ -65,7 +63,7 @@ const useFunnel = (steps: string[], completePath: string) => {
     if (prevIndex >= 0) {
       setStep(steps[prevIndex]);
     } else {
-      navigate(-1);
+      router.back();
     }
   };
 

--- a/src/hooks/useNavigateTo.tsx
+++ b/src/hooks/useNavigateTo.tsx
@@ -1,13 +1,13 @@
-import { useNavigate } from 'react-router-dom';
+import { useRouter } from 'next/navigation';
 
 const useNavigateTo = (routePage: string | number) => {
-  const navigate = useNavigate();
+  const router = useRouter();
 
   const navigateToPage = () => {
     if (typeof routePage === 'string') {
-      navigate(routePage);
+      router.push(routePage);
     } else if (typeof routePage === 'number') {
-      navigate(routePage);
+      router.back();
     }
   };
 

--- a/src/hooks/useScrollToTop.ts
+++ b/src/hooks/useScrollToTop.ts
@@ -1,15 +1,12 @@
+import { usePathname } from 'next/navigation';
 import { useEffect } from 'react';
-import { useLocation, useNavigationType } from 'react-router-dom';
 
 const ScrollToTop = () => {
-  const { pathname } = useLocation();
-  const navigationType = useNavigationType();
+  const pathname = usePathname();
 
   useEffect(() => {
-    if (navigationType !== 'POP') {
-      window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
-    }
-  }, [pathname, navigationType]);
+    window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+  }, [pathname]);
 
   return null;
 };

--- a/src/router/PrivateRoute.tsx
+++ b/src/router/PrivateRoute.tsx
@@ -1,25 +1,35 @@
-import { ReactNode } from 'react';
-import { Navigate, useLocation } from 'react-router-dom';
+'use client';
+
+import { usePathname, useSearchParams, useRouter } from 'next/navigation';
+import { ReactNode, useEffect } from 'react';
 
 interface PrivateRouteProps {
   children: ReactNode;
   redirectPath: string;
-  state?: { type: 'my' | 'wish' };
+  state?: { type: 'my' | 'wish' }; // ✅ 쿼리스트링으로 encode 가능
 }
 
 const PrivateRoute = ({ children, redirectPath, state }: PrivateRouteProps) => {
-  const isAuthenticated = localStorage.getItem('Authorization');
-  const location = useLocation();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
 
-  if (!isAuthenticated) {
-    const queryString = location.search;
-    return (
-      <Navigate
-        to={`${redirectPath}${queryString}`}
-        state={{ ...state, from: location.pathname, isPrivate: true }}
-      />
-    );
-  }
+  const isAuthenticated = localStorage.getItem('Authorization');
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      const query = new URLSearchParams({
+        ...Object.fromEntries(searchParams.entries()),
+        ...(state ? state : {}),
+        from: pathname,
+        isPrivate: 'true',
+      });
+
+      router.replace(`${redirectPath}?${query.toString()}`);
+    }
+  }, [isAuthenticated, router, pathname, searchParams, state]);
+
+  if (!isAuthenticated) return null;
 
   return <>{children}</>;
 };


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #272

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- react-router-dom 제거 및 next/navigation 기반 라우팅으로 전환했어요.
- @dotlottie/player-component를 SSR 환경에서 안전하게 로딩하도록 동적 import를 적용했어요

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 기존에 사용하던 react-router-dom을 제거하고 next.js App Router 환경에 맞게 next/navigation 모듈을 사용하여 라우팅 구조를 변경했어요. next.js에서는 별도의 클라이언트 라우터 라이브러리 없이 useRouter, usePathname, useSearchParams 등 next 내장 훅으로 라우팅이 가능하므로 이에 맞춰 전체 라우팅 로직을 수정했어요.
- @dotlottie/player-component는 웹 컴포넌트 기반으로 브라우저 전용 API(window, document 등)를 사용해서 Next.js와 같은 SSR 환경에서 정적으로 import할 경우 서버 렌더링 시 오류가 발생하였어요. 이를 방지하기 위해 useEffect 내부에서 동적으로 import하도록 `LottiePlayer` 컴포넌트를 만들어서 해당 컴포넌트가 클라이언트에서만 로딩되게하여 SSR 호환 문제가 해결했어요.

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->


목적 | 변경 전 (react-router-dom) | 변경 후 (next/navigation) | 설명
-- | -- | -- | --
페이지 이동 | useNavigate() → navigate('/about') | useRouter().push('/about') | 클라이언트에서 페이지 전환
URL 파라미터 (ex. /post/:id) | useParams() | useParams() | 동적 세그먼트 값 가져오기 (예: [id])
쿼리스트링 (ex. ?page=2) | useSearchParams() → .get('page') | useSearchParams() → .get('page') | URL 쿼리 값 접근
현재 경로 확인 | useLocation().pathname | usePathname() | 현재 페이지의 path 확인



## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->