### PR TITLE
[FEAT] 바텀시트 모달 UI 구현 및 필터 페이지를 필터 모달로 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
     "@vanilla-extract/vite-plugin": "^4.0.19",
     "axios": "^1.7.9",
     "jotai": "^2.11.1",
+    "motion": "^12.10.1",
     "next": "^15.2.4",
     "ol": "^10.3.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-modal-sheet": "^4.4.0",
     "react-router-dom": "^7.1.1",
     "storybook-addon-react-router-v6": "^2.0.15"
   },

--- a/src/app/searchResult/page.tsx
+++ b/src/app/searchResult/page.tsx
@@ -48,7 +48,7 @@ const SearchResultPage = () => {
     };
 
     fetchSearchResults();
-  }, [content, page]);
+  }, [searchParams.toString()]);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [currentPage, setCurrentPage] = useState(page);

--- a/src/components/common/bottmsheet/BottomSheet.tsx
+++ b/src/components/common/bottmsheet/BottomSheet.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from 'react';
+import { Sheet } from 'react-modal-sheet';
+
+import './bottomSheet.css';
+
+interface BottomSheetProps {
+  header?: ReactNode;
+  isOpen: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+const BottomSheet = ({ header, isOpen, onClose, children }: BottomSheetProps) => {
+  return (
+    <Sheet isOpen={isOpen} onClose={onClose} className="react-modal-sheet" detent="content-height">
+      <Sheet.Container>
+        {header && <Sheet.Header>{header}</Sheet.Header>}
+        <Sheet.Content>{children}</Sheet.Content>
+      </Sheet.Container>
+      <Sheet.Backdrop onTap={onClose} />
+    </Sheet>
+  );
+};
+
+export default BottomSheet;

--- a/src/components/common/bottmsheet/BottomSheet.tsx
+++ b/src/components/common/bottmsheet/BottomSheet.tsx
@@ -14,6 +14,7 @@ const BottomSheet = ({ header, isOpen, onClose, children }: BottomSheetProps) =>
   return (
     <Sheet isOpen={isOpen} onClose={onClose} className="react-modal-sheet" detent="content-height">
       <Sheet.Container>
+        <div className="modal-header-rectangle" />
         {header && <Sheet.Header>{header}</Sheet.Header>}
         <Sheet.Content>{children}</Sheet.Content>
       </Sheet.Container>

--- a/src/components/common/bottmsheet/bottomSheet.css
+++ b/src/components/common/bottmsheet/bottomSheet.css
@@ -1,0 +1,23 @@
+.react-modal-sheet-backdrop {
+  background-color: rgba(0, 0, 0, 0.45) !important;
+  max-width: 37.5rem;
+  left: auto !important;
+}
+
+.react-modal-sheet-content {
+  align-items: center;
+  overflow-y: auto;
+}
+
+.react-modal-sheet-container {
+  width: 100%;
+  height: 90%;
+  max-width: 37.5rem;
+  left: auto !important;
+}
+
+.react-modal-sheet {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}

--- a/src/components/common/bottmsheet/bottomSheet.css
+++ b/src/components/common/bottmsheet/bottomSheet.css
@@ -14,10 +14,20 @@
   height: 90%;
   max-width: 37.5rem;
   left: auto !important;
+  border-radius: 24px !important;
+  align-items: center;
 }
 
 .react-modal-sheet {
   display: flex;
   justify-content: center;
   width: 100%;
+}
+
+.modal-header-rectangle {
+  width: 3.3rem;
+  height: 0.5rem;
+  border-radius: 20px;
+  background-color: #e1e4e7;
+  margin-top: 1.5rem;
 }

--- a/src/components/common/bottmsheet/bottomSheet.css
+++ b/src/components/common/bottmsheet/bottomSheet.css
@@ -11,10 +11,10 @@
 
 .react-modal-sheet-container {
   width: 100%;
-  height: 90%;
   max-width: 37.5rem;
   left: auto !important;
-  border-radius: 24px !important;
+  border-top-right-radius: 24px !important;
+  border-top-left-radius: 24px !important;
   align-items: center;
 }
 

--- a/src/components/common/button/basicBtn/basicBtn.css.ts
+++ b/src/components/common/button/basicBtn/basicBtn.css.ts
@@ -7,7 +7,6 @@ const buttonStyle = recipe({
     justifyContent: 'center',
     alignItems: 'center',
     borderRadius: '40px',
-    transition: 'background-color 0.2s, color 0.2s, border 0.2s', // 임시로 넣어놓은 transition
     boxSizing: 'border-box',
   },
 

--- a/src/components/common/button/textBtn/TextBtn.tsx
+++ b/src/components/common/button/textBtn/TextBtn.tsx
@@ -24,13 +24,9 @@ const TextBtn = ({
 
   return (
     <button className={styles.textBtnStyle({ clicked, size })} onClick={onClick}>
-      {LeftIconComponent && (
-        <img src={LeftIconComponent} className={styles.iconStyle({ size })} alt="" />
-      )}
+      {LeftIconComponent && <LeftIconComponent />}
       <span>{text}</span>
-      {RightIconComponent && (
-        <img src={RightIconComponent} className={styles.iconStyle({ size })} alt="" />
-      )}
+      {RightIconComponent && <RightIconComponent />}
     </button>
   );
 };

--- a/src/components/common/button/underlinedBtn/underlinedBtn.css.ts
+++ b/src/components/common/button/underlinedBtn/underlinedBtn.css.ts
@@ -11,7 +11,7 @@ const ButtonStyle = recipe({
     isActive: {
       true: {
         color: theme.COLORS.black,
-        boxShadow: `0 1px 0 0 ${theme.COLORS.black}`,
+        boxShadow: `inset 0 -1px 0 0 ${theme.COLORS.black}`,
       },
       false: {
         color: theme.COLORS.gray9,

--- a/src/components/common/pagination/Pagination.tsx
+++ b/src/components/common/pagination/Pagination.tsx
@@ -43,7 +43,6 @@ const Pagination = ({ currentPage, totalPages, onPageChange, color }: Pagination
         onClick={() => onPageChange(Math.max(1, rangeStart - PAGINATION_UNIT))}
         disabled={isLeftDisabled}>
         <Icon.IcnLineArrowSmallLeft
-          alt="이전 페이지"
           className={isLeftDisabled ? styles.disabledIcon : styles.iconStyle}
         />
       </button>
@@ -54,7 +53,6 @@ const Pagination = ({ currentPage, totalPages, onPageChange, color }: Pagination
         disabled={isRightDisabled}>
         <Icon.IcnLineArrowSmallRight
           className={isRightDisabled ? styles.disabledIcon : styles.iconStyle}
-          alt="다음 페이지"
         />
       </button>
     </nav>

--- a/src/components/common/tapBar/TapBar.tsx
+++ b/src/components/common/tapBar/TapBar.tsx
@@ -6,15 +6,16 @@ import FILTERS from '@constants/filters';
 import { TapType, TAPS } from '@constants/taps';
 import useMoveScroll from '@hooks/useMoveScroll';
 import useScrollTracker from '@hooks/useScrollTrack';
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import useEventLogger from 'src/gtm/hooks/useEventLogger';
 
 interface TapBarProps {
   type: TapType;
   selectedTap?: string;
+  scrollContainerRef?: React.RefObject<HTMLDivElement>;
 }
 
-const TapBar = ({ type, selectedTap }: TapBarProps) => {
+const TapBar = ({ type, selectedTap, scrollContainerRef }: TapBarProps) => {
   const headerHeight = type === 'filter' ? HEADER_HEIGHT : DETAIL_HEADER_HEIGHT;
   const taplist = TAPS[type];
   const sectionIds =
@@ -22,13 +23,17 @@ const TapBar = ({ type, selectedTap }: TapBarProps) => {
       ? Object.keys(FILTERS)
       : TAPS.detail.map((_, index) => `detail-section-${index}`);
 
-  const { scrollIndex, handleClick } = useScrollTracker(sectionIds, headerHeight);
+  const { scrollIndex, handleClick } = useScrollTracker(
+    sectionIds,
+    headerHeight,
+    scrollContainerRef?.current,
+  );
   const scrollToElement = useMoveScroll(headerHeight);
   const { logClickEvent } = useEventLogger('filter_tag');
 
   const handleTabClick = (index: number) => {
     handleClick(index);
-    scrollToElement(sectionIds, index);
+    scrollToElement(sectionIds, index, scrollContainerRef?.current);
 
     if (type === 'filter') {
       logClickEvent('click_tag', {
@@ -47,7 +52,7 @@ const TapBar = ({ type, selectedTap }: TapBarProps) => {
       const selectedIndex = sectionIds.indexOf(selectedTap);
       if (selectedIndex !== -1) {
         handleClick(selectedIndex);
-        scrollToElement(sectionIds, selectedIndex);
+        scrollToElement(sectionIds, selectedIndex, scrollContainerRef?.current);
       }
     }
   }, []);

--- a/src/components/filter/filterBottomSheetModal/FilterBottomSheetModal.tsx
+++ b/src/components/filter/filterBottomSheetModal/FilterBottomSheetModal.tsx
@@ -1,0 +1,40 @@
+import BottomSheet from '@components/common/bottmsheet/BottomSheet';
+import TapBar from '@components/common/tapBar/TapBar';
+import FilterModalContent from '@components/filter/filterBottomSheetModal/FilterModalContent';
+import { useRef } from 'react';
+
+import * as styles from './filterModal.css';
+
+interface FilterBottomSheetModalProps {
+  selectedTap: string;
+  handleCloseModal: () => void;
+  isOpen: boolean;
+}
+
+const FilterBottomSheetModal = ({
+  selectedTap,
+  handleCloseModal,
+  isOpen,
+}: FilterBottomSheetModalProps) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <BottomSheet
+      isOpen={isOpen}
+      onClose={handleCloseModal}
+      header={
+        <>
+          <h1 className={styles.titleStyle}>필터</h1>
+          <TapBar
+            type="filter"
+            selectedTap={selectedTap ?? undefined}
+            scrollContainerRef={scrollRef}
+          />
+        </>
+      }>
+      <FilterModalContent onComplete={handleCloseModal} scrollRef={scrollRef} />
+    </BottomSheet>
+  );
+};
+
+export default FilterBottomSheetModal;

--- a/src/components/filter/filterBottomSheetModal/FilterModalContent.tsx
+++ b/src/components/filter/filterBottomSheetModal/FilterModalContent.tsx
@@ -1,0 +1,55 @@
+import ButtonBar from '@components/common/button/buttonBar/ButtonBar';
+import Divider from '@components/common/divider/Divider';
+import FilterBox from '@components/filter/filterBox/FilterBox';
+import FILTERS from '@constants/filters';
+import useFilter from '@hooks/useFilter';
+import { useAtomValue } from 'jotai';
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
+import { filterListAtom } from 'src/store/store';
+import titleMap from 'src/type/titleMap';
+
+import * as styles from './filterModalContent.css';
+
+interface Props {
+  onComplete?: () => void;
+  scrollRef: React.RefObject<HTMLDivElement>;
+}
+
+const FilterModalContent = ({ onComplete, scrollRef }: Props) => {
+  const { totalCount, toggleFilter, handleResetFilter, handleSearch } = useFilter();
+  const filterInstance = useAtomValue(filterListAtom);
+  const filtersState = filterInstance.getAllStates();
+  const { logClickEvent } = useEventLogger('filter_tag');
+
+  const searchFilter = async () => {
+    await handleSearch();
+    logClickEvent('click_list', { label: '' });
+    onComplete?.();
+  };
+
+  return (
+    <>
+      <main className={styles.main} ref={scrollRef}>
+        {Object.entries(FILTERS).map(([key, items]) => (
+          <div key={key}>
+            <FilterBox
+              title={titleMap[key]}
+              items={items}
+              id={key}
+              filtersState={filtersState}
+              onToggleFilter={toggleFilter}
+            />
+            <Divider />
+          </div>
+        ))}
+      </main>
+      <ButtonBar
+        type="reset"
+        label={`${totalCount || 0}개의 템플스테이 보기`}
+        largeBtnClick={searchFilter}
+        handleResetFilter={handleResetFilter}
+      />
+    </>
+  );
+};
+export default FilterModalContent;

--- a/src/components/filter/filterBottomSheetModal/filterModal.css.ts
+++ b/src/components/filter/filterBottomSheetModal/filterModal.css.ts
@@ -25,7 +25,7 @@ export const titleStyle = style({
   width: '100%',
   height: '4rem',
   marginBottom: '1.2rem',
-  marginTop: '3.4rem',
+  marginTop: '1.4rem',
   ...theme.FONTS.h3Sb18,
   color: theme.COLORS.black,
 });

--- a/src/components/filter/filterBottomSheetModal/filterModalContent.css.ts
+++ b/src/components/filter/filterBottomSheetModal/filterModalContent.css.ts
@@ -1,0 +1,16 @@
+import theme from '@styles/theme.css';
+import { style } from '@vanilla-extract/css';
+
+export const header = style({
+  position: 'sticky',
+  top: 0,
+  background: theme.COLORS.white,
+});
+
+export const main = style({
+  padding: '0 2rem',
+  marginBottom: '7rem',
+  overflowY: 'auto',
+  maxHeight: 'calc(100vh - 280px)',
+  height: '100vh',
+});

--- a/src/components/filter/filterTypeBox/FilterTypeBox.tsx
+++ b/src/components/filter/filterTypeBox/FilterTypeBox.tsx
@@ -1,6 +1,7 @@
 import Icon from '@assets/svgs';
 import BasicBtn from '@components/common/button/basicBtn/BasicBtn';
-import { useRouter } from 'next/navigation';
+import FilterBottomSheetModal from '@components/filter/filterBottomSheetModal/FilterBottomSheetModal';
+import { useState } from 'react';
 import titleMap from 'src/type/titleMap';
 
 import * as styles from './filterTypeBox.css';
@@ -10,10 +11,16 @@ interface FilterTypeBoxProps {
 }
 
 const FilterTypeBox = ({ activeFilters }: FilterTypeBoxProps) => {
-  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedTap, setSelectedTap] = useState<string>('region');
 
   const handleClickFilter = (filter: string) => {
-    router.push(`/filter?selectedTap=${filter}`);
+    setSelectedTap(filter);
+    setIsOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsOpen(false);
   };
 
   return (
@@ -33,6 +40,11 @@ const FilterTypeBox = ({ activeFilters }: FilterTypeBoxProps) => {
             />
           );
         })}
+        <FilterBottomSheetModal
+          selectedTap={selectedTap}
+          isOpen={isOpen}
+          handleCloseModal={handleCloseModal}
+        />
       </div>
     </div>
   );

--- a/src/components/templeDetail/templeInfo/contentCollapse/ContentCollapse.tsx
+++ b/src/components/templeDetail/templeInfo/contentCollapse/ContentCollapse.tsx
@@ -13,7 +13,7 @@ const ContentCollapse = ({ leftIcon, text, onClick }: ContetnCollapseProps) => {
   return (
     <div className={styles.contentCollapseContainer}>
       <button className={styles.collapseButtonBox} onClick={onClick}>
-        <img src={LeftIconComponent} alt="" />
+        <LeftIconComponent aria-hidden />
         {text}
       </button>
     </div>

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,4 +1,4 @@
-export const HEADER_HEIGHT = 92;
+export const HEADER_HEIGHT = 0;
 
 export const DETAIL_HEADER_HEIGHT = 142;
 

--- a/src/hooks/useFilter.ts
+++ b/src/hooks/useFilter.ts
@@ -90,6 +90,14 @@ const useFilter = () => {
         maxPrice: String(price.maxPrice),
       });
 
+      Object.entries(groupedFilters).forEach(([groupKey, groupValues]) => {
+        Object.entries(groupValues).forEach(([key, isSelected]) => {
+          if (isSelected) {
+            searchParams.append(groupKey, key);
+          }
+        });
+      });
+
       router.push(`/searchResult?${searchParams.toString()}`);
       return response;
     } catch (error) {

--- a/src/hooks/useMoveScroll.ts
+++ b/src/hooks/useMoveScroll.ts
@@ -2,22 +2,36 @@ import { useCallback } from 'react';
 
 const useMoveScroll = (headerHeight: number = 0) => {
   const scrollToElement = useCallback(
-    async (sectionIds: string[], activeIndex: number): Promise<void> => {
-      const targetElement = document.getElementById(sectionIds[activeIndex]);
+    async (
+      sectionIds: string[],
+      activeIndex: number,
+      scrollContainer?: HTMLElement | null,
+    ): Promise<void> => {
+      const container = scrollContainer ?? window;
 
-      if (targetElement) {
-        const elementPosition = targetElement.getBoundingClientRect().top;
-        const offsetPosition = window.scrollY + elementPosition - headerHeight;
+      const targetElement =
+        container instanceof Window
+          ? document.getElementById(sectionIds[activeIndex])
+          : (container.querySelector(`#${sectionIds[activeIndex]}`) as HTMLElement);
 
-        window.scrollTo({
-          top: offsetPosition,
-          behavior: 'smooth',
-        });
+      if (!targetElement) return;
 
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 500);
-        });
+      const offsetTop =
+        container instanceof Window
+          ? targetElement.getBoundingClientRect().top + window.scrollY
+          : targetElement.offsetTop;
+
+      const scrollTop = offsetTop - headerHeight;
+
+      if (container instanceof Window) {
+        window.scrollTo({ top: scrollTop, behavior: 'smooth' });
+      } else {
+        container.scrollTo({ top: scrollTop, behavior: 'smooth' });
       }
+
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 1000);
+      });
     },
     [headerHeight],
   );

--- a/src/hooks/useScrollTrack.tsx
+++ b/src/hooks/useScrollTrack.tsx
@@ -1,19 +1,34 @@
 'use client';
 import { useEffect, useRef, useState } from 'react';
 
-const useScrollTracker = (sections: string[], headerHeight: number = 0) => {
+const useScrollTracker = (
+  sections: string[],
+  headerHeight: number = 0,
+  scrollContainer?: HTMLElement | null,
+) => {
   const [scrollIndex, setScrollIndex] = useState(0);
   const isClicked = useRef(false);
 
   useEffect(() => {
+    const container = scrollContainer ?? window;
+
+    const getScrollTop = () =>
+      container instanceof Window ? container.scrollY : container.scrollTop;
+
+    const getElement = (id: string): HTMLElement | null => {
+      return container instanceof Window
+        ? document.getElementById(id)
+        : (container.querySelector(`#${id}`) as HTMLElement | null);
+    };
+
     const handleScroll = () => {
       if (isClicked.current) return;
 
-      const scrollPosition = window.scrollY + headerHeight;
+      const scrollPosition = getScrollTop() + headerHeight;
       let newIndex = -1;
 
       sections.forEach((sectionId, index) => {
-        const element = document.getElementById(sectionId);
+        const element = getElement(sectionId);
         if (!element) return;
 
         const elementTop = element.offsetTop;
@@ -25,7 +40,11 @@ const useScrollTracker = (sections: string[], headerHeight: number = 0) => {
         }
       });
 
-      const pageBottom = window.innerHeight + window.scrollY >= document.body.offsetHeight;
+      const pageBottom =
+        container instanceof Window
+          ? window.innerHeight + window.scrollY >= document.body.offsetHeight
+          : container.scrollTop + container.clientHeight >= container.scrollHeight;
+
       if (pageBottom) {
         newIndex = sections.length - 1;
       }
@@ -35,12 +54,12 @@ const useScrollTracker = (sections: string[], headerHeight: number = 0) => {
       }
     };
 
-    window.addEventListener('scroll', handleScroll, { passive: true });
+    container.addEventListener('scroll', handleScroll, { passive: true });
 
     return () => {
-      window.removeEventListener('scroll', handleScroll);
+      container.removeEventListener('scroll', handleScroll);
     };
-  }, [sections, headerHeight, scrollIndex]);
+  }, [sections, scrollContainer, headerHeight, scrollIndex]);
 
   const handleClick = (index: number) => {
     isClicked.current = true;

--- a/src/styles/theme.css.ts
+++ b/src/styles/theme.css.ts
@@ -17,6 +17,7 @@ const theme = createGlobalTheme(':root', {
     black: '#121212',
     white: '#ffffff',
     black60: 'rgba(18, 18, 18, 0.6)',
+    black65: 'rgba(0, 0, 0, 0.65)',
 
     primary200: '#9FECAD',
     primary400: '#65C677',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4381,6 +4381,15 @@ form-data@^4.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+framer-motion@^12.10.1:
+  version "12.10.1"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-12.10.1.tgz#24f30455f54cb6f2cff6dc0e0aa8e31c88d6a3a7"
+  integrity sha512-g+fANUVC17SzQc6eA0CtomBW4n67ckhS2hq5fjkKZneKzv7sbdXK3zzjnnAKB22Ck+Qhh+IlO5RjHNKULsq99Q==
+  dependencies:
+    motion-dom "^12.10.1"
+    motion-utils "^12.9.4"
+    tslib "^2.4.0"
+
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -5150,6 +5159,26 @@ modern-ahocorasick@^1.0.0:
   resolved "https://registry.yarnpkg.com/modern-ahocorasick/-/modern-ahocorasick-1.1.0.tgz#9b1fa15d4f654be20a2ad7ecc44ec9d7645bb420"
   integrity sha512-sEKPVl2rM+MNVkGQt3ChdmD8YsigmXdn5NifZn6jiwn9LRJpWm8F3guhaqrJT/JOat6pwpbXEk6kv+b9DMIjsQ==
 
+motion-dom@^12.10.1:
+  version "12.10.1"
+  resolved "https://registry.yarnpkg.com/motion-dom/-/motion-dom-12.10.1.tgz#7767179e0eba58b31256fdcde9ef92b162e734d2"
+  integrity sha512-rY8DNqgKh4LeFSQBkuXpe/7sycYS9RM+4luukjHpHogF1liSvIp0Hedx0q2QsWNz+AHuZ5bZQ9j9QZSUCA8bbw==
+  dependencies:
+    motion-utils "^12.9.4"
+
+motion-utils@^12.9.4:
+  version "12.9.4"
+  resolved "https://registry.yarnpkg.com/motion-utils/-/motion-utils-12.9.4.tgz#9d5a45a19971e20059911526d7af2217c5158fa2"
+  integrity sha512-BW3I65zeM76CMsfh3kHid9ansEJk9Qvl+K5cu4DVHKGsI52n76OJ4z2CUJUV+Mn3uEP9k1JJA3tClG0ggSrRcg==
+
+motion@^12.10.1:
+  version "12.10.1"
+  resolved "https://registry.yarnpkg.com/motion/-/motion-12.10.1.tgz#faf607bc550104201e5ddf7a4d3e2f5fb179e11c"
+  integrity sha512-WBpo3oiIQRDMQqMRn3DAgBJrjqGMKY+BomsINn67ot8c+691pwHvUUo+kvknck7kNkUPOAq2EHbAEwlx+5Vfow==
+  dependencies:
+    framer-motion "^12.10.1"
+    tslib "^2.4.0"
+
 ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
@@ -5585,6 +5614,11 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-modal-sheet@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/react-modal-sheet/-/react-modal-sheet-4.4.0.tgz#f19cd4c1624ff779d4dcd3e556e3799cc64a23f2"
+  integrity sha512-ub42vR7iwjdM/2Zl6uZoH5M5Dcb6KTuVaOQ+uQCIlo10SdlYAhksb6u3eIFSLohFrX5q03rgFnR6Y0PKhjjl/Q==
 
 react-refresh@^0.14.2:
   version "0.14.2"


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #276

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- react-modal-sheet을 사용해서 bottom sheet모달을 구현했어요.
- BottomSheet는 header와 children을 받아서 바텀 시트 모달이 구현 가능하도록 했어요.
- BottomSheet 컴포넌트를 사용해서 FilterBottomSheetModal을 구현했어요.
- 기존 tapbar의 경우에는 window를 기준으로 스크롤을 이동시켰는데 모달안에 필터들을 넣음으로서 window기준이 아니라 해당
모달을 기준삼아서 스크롤을 움직이기 위해서 scrollContainerRef를 옵셔널로 받아서 각 필터에 따라 모달내에서도 필터링이 움직일 수 있도록 구현했어요.

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- react-modal-sheet의 스타일을 수정할때 !important를 사용하기 위해서 css로 스타일을 지정했어요. vallia-exract에서는 !important를 사용할 수 없는 것으로 알고 있는데 다른 방법 아신다면 말씀 부탁드립니다!


<img width="380" alt="image" src="https://github.com/user-attachments/assets/dd990819-f4c8-437c-ae98-9f1eb72755eb" />

- 기본 BottomSheet 컴포넌트는 다음과 같은 형태이니 bottomSheet를 사용하실 때 아래와 같이 open관련 상태와 header, content만 넣어서 사용하시면 됩니다!

``` tsx
 <BottomSheet
      isOpen={isOpen}
      onClose={handleCloseModal}
      header={ // 바텀 시트에 header가 있는 경우는 header 넣기
        <>
          <h1 className={styles.titleStyle}>필터</h1>
          <TapBar
            type="filter"
            selectedTap={selectedTap ?? undefined}
            scrollContainerRef={scrollRef}
          />
        </>
      }>

      // children으로 모달 콘텐츠 넣기
      <FilterModalContent onComplete={handleCloseModal} scrollRef={scrollRef} /> 
    </BottomSheet>
```

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- 

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->
![May-09-2025 16-19-28](https://github.com/user-attachments/assets/2bab7cfd-5e49-4e6d-ae4b-87a5a450cd37)



