### PR TITLE
[FEAT] 홈페이지 클라이언트 컴포넌트 분리 및 next/Image 적용

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,9 @@ const withVanillaExtract = createVanillaExtractPlugin();
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  images: {
+    domains: ['noms.templestay.com'],
+  },
   webpack(config) {
     config.module.rules.push({
       test: /\.svg$/,

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import PopularCarousel from '@components/carousel/popularCarousel/PopularCarousel';
+import ModalContainer from '@components/common/modal/ModalContainer';
+import useFilter from '@hooks/useFilter';
+import useNavigateTo from '@hooks/useNavigateTo';
+import { useSetAtom } from 'jotai';
+import { useEffect, useState } from 'react';
+import useEventLogger from 'src/gtm/hooks/useEventLogger';
+import { contentAtom } from 'src/store/store';
+
+import * as styles from './homePage.css';
+
+const HomeClient = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const navigateToLogin = useNavigateTo('/loginStart');
+  const { logClickEvent } = useEventLogger('modal_login_wish');
+
+  const { handleResetFilter } = useFilter();
+  const setContent = useSetAtom(contentAtom);
+
+  useEffect(() => {
+    setContent('');
+    handleResetFilter();
+    localStorage.setItem('prevPage', '/');
+  }, []);
+
+  const handleLogin = () => {
+    navigateToLogin();
+    logClickEvent('click_login');
+  };
+
+  const handleClose = () => {
+    setIsModalOpen(false);
+    logClickEvent('click_cancel');
+  };
+
+  return (
+    <>
+      {isModalOpen && (
+        <div className={styles.modalOverlay}>
+          <ModalContainer
+            modalTitle="로그인 하시겠어요?"
+            modalBody="찜하려면 로그인이 필요해요."
+            isOpen={isModalOpen}
+            handleClose={handleClose}
+            handleSubmit={handleLogin}
+            leftBtnLabel="취소"
+            rightBtnLabel="로그인하기"
+          />
+        </div>
+      )}
+      <PopularCarousel onRequireLogin={() => setIsModalOpen(true)} />
+    </>
+  );
+};
+
+export default HomeClient;

--- a/src/app/homePage.css.ts
+++ b/src/app/homePage.css.ts
@@ -6,7 +6,6 @@ const flexCenterColumn = style({
   flexDirection: 'column',
   alignItems: 'center',
   justifyContent: 'center',
-  position: 'relative',
 });
 
 export const homeWrapper = flexCenterColumn;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,53 +1,19 @@
 'use client';
+
 import { useGetNickname } from '@apis/user';
+import HomeClient from '@app/HomeClient';
 import LookCard from '@components/card/lookCard/LookCard';
 import MapCard from '@components/card/mapCard/MapCard';
 import CurationCarousel from '@components/carousel/curationCarousel/CurationCarousel';
-import PopularCarousel from '@components/carousel/popularCarousel/PopularCarousel';
-import ModalContainer from '@components/common/modal/ModalContainer';
 import DetailTitle from '@components/detailTitle/DetailTitle';
 import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
 import Footer from '@components/footer/Footer';
 import Header from '@components/header/Header';
-import useFilter from '@hooks/useFilter';
 import { getStorageValue } from '@hooks/useLocalStorage';
-import useNavigateTo from '@hooks/useNavigateTo';
-import { useSetAtom } from 'jotai';
-import { useEffect, useState } from 'react';
-import useEventLogger from 'src/gtm/hooks/useEventLogger';
-import { contentAtom } from 'src/store/store';
 
 import * as styles from './homePage.css';
 
 const HomePage = () => {
-  const { handleResetFilter } = useFilter();
-  const setContent = useSetAtom(contentAtom);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-
-  const navigateToLogin = useNavigateTo('/loginStart');
-  const { logClickEvent } = useEventLogger('modal_login_wish');
-
-  const handleLogin = () => {
-    navigateToLogin();
-    logClickEvent('click_login');
-  };
-
-  const openModal = () => {
-    setIsModalOpen(true);
-  };
-
-  const closeModal = () => {
-    setIsModalOpen(false);
-
-    logClickEvent('click_cancel');
-  };
-
-  useEffect(() => {
-    setContent('');
-    handleResetFilter();
-    localStorage.setItem('prevPage', '/');
-  }, []);
-
   const userId = Number(getStorageValue('userId'));
   const { data, isLoading } = useGetNickname(userId);
 
@@ -57,20 +23,6 @@ const HomePage = () => {
 
   return (
     <div className={styles.homeWrapper}>
-      {isModalOpen && (
-        <div className={styles.modalOverlay}>
-          <ModalContainer
-            modalTitle="로그인 하시겠어요?"
-            modalBody="찜하려면 로그인이 필요해요."
-            isOpen={isModalOpen}
-            handleClose={closeModal}
-            handleSubmit={handleLogin}
-            leftBtnLabel="취소"
-            rightBtnLabel="로그인하기"
-          />
-        </div>
-      )}
-
       <Header />
       <LookCard name={data?.nickname} />
       <MapCard />
@@ -80,7 +32,7 @@ const HomePage = () => {
       </div>
       <div className={styles.popularCarouselStyle}>
         <DetailTitle title="이번 주 인기 템플스테이" />
-        <PopularCarousel onRequireLogin={openModal} />
+        <HomeClient /> {/* 인기 템플스테이 캐러셀 */}
       </div>
       <Footer />
     </div>

--- a/src/components/card/popularCard/PopularCard.tsx
+++ b/src/components/card/popularCard/PopularCard.tsx
@@ -1,7 +1,9 @@
 'use client';
+
 import Icon from '@assets/svgs';
 import RankBtn from '@components/card/popularCard/RankBtn';
 import { getStorageValue } from '@hooks/useLocalStorage';
+import Image from 'next/image';
 import { useState } from 'react';
 
 import * as styles from './popularCard.css';
@@ -50,7 +52,13 @@ const PopularCard = ({
       draggable={false}
       onDragStart={(e) => e.preventDefault()}>
       <div>
-        <div className={styles.imgBox} style={{ backgroundImage: `url(${templeImg})` }}>
+        <div className={styles.imgBox}>
+          <Image
+            src={templeImg}
+            alt={`${templeName} 대표 이미지`}
+            fill
+            style={{ objectFit: 'cover' }}
+          />
           <RankBtn ranking={ranking} />
         </div>
         <div className={styles.bottomWrapper}>

--- a/src/components/card/popularCard/popularCard.css.ts
+++ b/src/components/card/popularCard/popularCard.css.ts
@@ -41,8 +41,8 @@ export const imgBox = style({
   justifyContent: 'flex-end',
   color: theme.COLORS.white,
   overflow: 'hidden',
-  backgroundSize: 'cover',
   backgroundPosition: 'center',
+  position: 'relative',
 });
 
 export const bottomContainer = style({

--- a/src/components/common/button/basicBtn/BasicBtn.tsx
+++ b/src/components/common/button/basicBtn/BasicBtn.tsx
@@ -1,5 +1,6 @@
 import Icon from '@assets/svgs';
-import buttonStyle from '@components/common/button/basicBtn/basicBtn.css';
+
+import * as styles from './basicBtn.css';
 
 interface ButtonProps {
   variant?: 'primary' | 'grayOutlined' | 'blackOutlined' | 'lightGrayOutlined' | 'green';
@@ -27,9 +28,13 @@ const BasicBtn = ({
 
   return (
     <button
-      className={buttonStyle({ color: variant, size, active: isActive ? true : false })}
+      className={styles.buttonStyle({ color: variant, size, active: isActive ? true : false })}
       onClick={onClick}>
-      {SelectedLeftIcon && <SelectedLeftIcon />}
+      {SelectedLeftIcon && (
+        <span className={styles.iconWrapper}>
+          <SelectedLeftIcon />
+        </span>
+      )}
       <p>{label}</p>
       {SelectedRightIcon && (
         <span
@@ -45,7 +50,8 @@ const BasicBtn = ({
               e.stopPropagation();
               onRightIconClick?.();
             }
-          }}>
+          }}
+          className={styles.iconWrapper}>
           <SelectedRightIcon />
         </span>
       )}

--- a/src/components/common/button/basicBtn/basicBtn.css.ts
+++ b/src/components/common/button/basicBtn/basicBtn.css.ts
@@ -1,7 +1,8 @@
 import theme from '@styles/theme.css';
+import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
-const buttonStyle = recipe({
+export const buttonStyle = recipe({
   base: {
     display: 'flex',
     justifyContent: 'center',
@@ -144,4 +145,8 @@ const buttonStyle = recipe({
   },
 });
 
-export default buttonStyle;
+export const iconWrapper = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+});

--- a/src/components/curation/curationCard/CurationCard.tsx
+++ b/src/components/curation/curationCard/CurationCard.tsx
@@ -1,3 +1,5 @@
+import Image from 'next/image';
+
 import * as styles from './curationCard.css';
 
 interface CurationCardProps {
@@ -12,9 +14,9 @@ const CurationCard = ({ bgImage, title, subtitle, link }: CurationCardProps) => 
     <a
       href={link}
       className={styles.cardContainer}
-      style={{ backgroundImage: `url(${bgImage})` }}
       draggable={false}
       onDragStart={(e) => e.preventDefault()}>
+      <Image src={bgImage} alt={title} fill style={{ objectFit: 'cover' }} />
       <div className={styles.textbox}>
         <p className={styles.title}>{title}</p>
         <p className={styles.subtitle}>{subtitle}</p>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #288 

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- SSR 적용을 위한 홈페이지 클라이언트 컴포넌트 분리 (`HomeClient.tsx`)
- 홈페이지 캐러셀에서 사용되는 카드 컴포넌트의 이미지를 style backgroundImage -> `next/Image` 로 변경
- `BasicBtn` 아이콘 중앙 정렬 안되는 이슈 해결 (SSR 관련 태스크는 아닌데 거슬려서 같이함)

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
(정답이 없는 부분이라 제 생각과 고민 과정을 적어두었습니다)

### SSR 적용을 위한 HomeClient.tsx 생성
홈페이지의 SSR 적용 및 성능 최적화를 위하여 기존 클라이언트 컴포넌트 중심 구조를 서버-클라이언트 분리 구조로 변경하였습니다. 

SSR 적용을 위해 해결이 필요했던 주요 항목들은 아래와 같았어요.
1. 유저 이름 받아오기
2. 인기 템플스테이 캐러셀
3. 모달 상태 관리
4. useEffect 내부의 초기화 코드들 (+ 로컬스토리지 prevPage 저장)

1,2번의 경우 현재는 로컬스토리지에서 토큰과 유저 아이디를 관리하고 있기 때문에 SSR 적용에 제약이 있어 todo로 남겨두었습니다.
(쿠키 기반 인증 방식 도입 이후 적용 예정 !)

3,4번을 두고 고민을 많이 했는데, 제가 생각한 해결책은 아래와 같았습니다.
- 모달 : Jotai를 사용해 전역 상태로 관리 / parallel routes / intercepting routes
- useEffect 내부의 초기화 코드들 : ?????

모달을 병렬 라우팅이나 인터셉트 라우팅으로 하기에는 이 모달을 위해 라우터 뎁스가 하나 더 생기는게 과하다고 생각했어요. useEffect 초기화 로직의 경우에는 이걸 어떻게 처리할지 갈피를 못 잡았습니다 😅 ....

➡️ 결국 그냥 클라이언트 로직 따로 빼는 게 깔끔 + 간단하겠다 싶어서 HomeClient.tsx로 분리하는 방식을 선택했어요. 더 나은 방식이 있다면 알려줘잉

### 고민되는 부분
PR 작성 중에 생각난건데, 
useEffect 내부의 초기화 로직이 홈 진입 시점에만 필요한 일회성 초기화니까 Jotai atom을 통해 트리거하는 방식도 옵션이 될 수 있을 것 같아요. 그렇게 되면 useEffect를 사용하지 않아도 될 것 같고, 모달 상태 관리도 함께 Jotai로 옮기면 클라이언트 컴포넌트를 따로 분리하지 않아도 될 것 같다는 생각이 드네용 . 어떠신지 ....


## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- 

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- [Next.js 서버 컴포넌트 vs 클라이언트 컴포넌트 이해와 실습](https://notavoid.tistory.com/109#%EC%84%9C%EB%B2%84%20%EC%BB%B4%ED%8F%AC%EB%84%8C%ED%8A%B8%EB%A5%BC%20%EC%82%AC%EC%9A%A9%ED%95%B4%EC%95%BC%20%ED%95%A0%20%EB%95%8C-1)

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->