### PR TITLE
[REFACTOR] Homepage 서버 컴포넌트 전환

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,22 +5,31 @@ const withVanillaExtract = createVanillaExtractPlugin();
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+
   images: {
     domains: ['noms.templestay.com'],
   },
+
   webpack(config) {
-    config.module.rules.push({
-      test: /\.svg$/,
-      issuer: /\.[jt]sx?$/,
-      use: [
-        {
-          loader: '@svgr/webpack',
-          options: {
-            memo: true,
-          },
-        },
-      ],
-    });
+    const fileLoaderRule = config.module.rules.find((rule) => rule.test?.test?.('.svg'));
+
+    config.module.rules.push(
+      {
+        ...fileLoaderRule,
+        test: /\.svg$/i,
+        resourceQuery: /url/,
+      },
+
+      {
+        test: /\.svg$/i,
+        issuer: fileLoaderRule.issuer,
+        resourceQuery: { not: [...fileLoaderRule.resourceQuery.not, /url/] },
+        use: ['@svgr/webpack'],
+      },
+    );
+
+    fileLoaderRule.exclude = /\.svg$/i;
+
     return config;
   },
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,30 +1,22 @@
-'use client';
-
-import { useGetNickname } from '@apis/user';
 import HomeClient from '@app/HomeClient';
 import LookCard from '@components/card/lookCard/LookCard';
 import MapCard from '@components/card/mapCard/MapCard';
 import CurationCarousel from '@components/carousel/curationCarousel/CurationCarousel';
 import DetailTitle from '@components/detailTitle/DetailTitle';
-import ExceptLayout from '@components/except/exceptLayout/ExceptLayout';
 import Footer from '@components/footer/Footer';
 import Header from '@components/header/Header';
-import { getStorageValue } from '@hooks/useLocalStorage';
+import { cookies } from 'next/headers';
 
 import * as styles from './homePage.css';
 
-const HomePage = () => {
-  const userId = Number(getStorageValue('userId'));
-  const { data, isLoading } = useGetNickname(userId);
-
-  if (isLoading) {
-    return <ExceptLayout type="loading" />;
-  }
+const HomePage = async () => {
+  const cookieStore = await cookies();
+  const userName = cookieStore.get('userNickname')?.value;
 
   return (
     <div className={styles.homeWrapper}>
       <Header />
-      <LookCard name={data?.nickname} />
+      <LookCard name={userName} />
       <MapCard />
       <div className={styles.curationCarouselStyle}>
         <DetailTitle title="절로가 PICK!" />

--- a/src/components/card/lookCard/LookCard.tsx
+++ b/src/components/card/lookCard/LookCard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import BasicBtn from '@components/common/button/basicBtn/BasicBtn';
 import useFilter from '@hooks/useFilter';
 import useEventLogger from 'src/gtm/hooks/useEventLogger';

--- a/src/components/card/mapCard/Map.tsx
+++ b/src/components/card/mapCard/Map.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import mapImage from '@assets/images/home_card_map.png';
 import LocBtn from '@components/card/mapCard/LocBtn';
 import { REGION_INFOS, REGION_LABEL_MAP } from '@constants/regionInfos';

--- a/src/components/carousel/curationCarousel/CurationCarousel.tsx
+++ b/src/components/carousel/curationCarousel/CurationCarousel.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import CurationCard from '@components/curation/curationCard/CurationCard';
 import { CURATION_INFO } from '@constants/curationInfo';
 import useCarousel from '@hooks/useCarousel';

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Icon from '@assets/svgs';
 import useEventLogger from 'src/gtm/hooks/useEventLogger';
 

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Icon from '@assets/svgs';
 import useNavigateTo from '@hooks/useNavigateTo';
 

--- a/src/components/search/searchBar/SearchBar.tsx
+++ b/src/components/search/searchBar/SearchBar.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import Icon from '@assets/svgs';
 import useFilter from '@hooks/useFilter';
 import { usePathname } from 'next/navigation';

--- a/src/hooks/useCarousel.ts
+++ b/src/hooks/useCarousel.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import { useState, useRef } from 'react';
 
 interface UseCarouselProps {

--- a/src/hooks/useFilter.ts
+++ b/src/hooks/useFilter.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import useFetchFilteredList from '@apis/filter';
 import { fetchFilteredCount } from '@apis/filter/axios';
 import useLocalStorage, { getStorageValue } from '@hooks/useLocalStorage';

--- a/src/hooks/useNavigateTo.tsx
+++ b/src/hooks/useNavigateTo.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useRouter } from 'next/navigation';
 
 const useNavigateTo = (routePage: string | number) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,6 +40,7 @@
     ]
   },
   "include": [
+    "svg.d.ts",
     "dist/types/**/*.ts",
     "next-env.d.ts",
     "public/assets",


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> 해결한 이슈 번호를 작성해주세요
close #301 

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 드디어 Homepage 서버 컴포넌트 전환 했습니다
- 홈페이지 / 온보딩 후 웰컴페이지 에서 유저 이름 쿠키에서 가져오도록 수정했습니다

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
기존 설정에서는 모든 .svg 파일을 @svgr/webpack을 통해 React 컴포넌트로 처리하도록 강제했는데, 이 방식이 Next.js의 기본 SVG 처리 방식과 충돌하여 Module parse failed 에러가 발생한 것 같습니다. 마이그레이션 하면서 이 부분을 놓친듯 .. next에 맞게 변경했습니다 ! [공식문서](https://react-svgr.com/docs/next/)

큰 흐름은 아래와 같아요.

- `*.svg?url `→ 기존처럼 이미지 URL로 처리 (file-loader 유지)
- `*.svg` → @svgr/webpack으로 React 컴포넌트로 변환
- 기존 로더에서 `.svg` 파일은 제외하여 충돌 방지



## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * SVG 파일을 URL 또는 React 컴포넌트로 구분하여 가져올 수 있도록 SVG 처리 방식을 개선하였습니다.

* **버그 수정**
  * 서버 컴포넌트에서 쿠키를 활용해 사용자 닉네임을 직접 가져오도록 변경하여, 로딩 상태 및 불필요한 클라이언트 측 데이터 요청을 제거하였습니다.

* **스타일**
  * 여러 컴포넌트 및 훅에 'use client' 지시문을 명확히 추가하여 클라이언트 사이드 렌더링 동작을 보장하였습니다.

* **문서화**
  * TypeScript 컴파일러가 SVG 타입 선언 파일을 포함하도록 설정을 업데이트하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->